### PR TITLE
feat: add semantic graph infrastructure and models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,7 @@ FRONTEND_PORT=3000
 
 OPENAIRE_BEGINNERS_KIT_PATH=./data/openaire/beginners_kit
 EUNIGRAPH_COAUTHORSHIP_GRAPH_STORAGE_PATH=./data/graphs/coauthorship
+EUNIGRAPH_SEMANTIC_GRAPH_STORAGE_PATH=./data/graphs/semantic
 
 # Gemini
 GEMINI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -150,3 +150,4 @@ See [docs/seed-and-api.md](/Users/cristianopistorio/Code/GitHub/EuniGraph/docs/s
 See [docs/normalization.md](/Users/cristianopistorio/Code/GitHub/EuniGraph/docs/normalization.md) for the current normalization and deduplication rules.
 See [docs/coauthorship.md](/Users/cristianopistorio/Code/GitHub/EuniGraph/docs/coauthorship.md) for the materialized coauthorship graph pipeline.
 See [docs/embeddings.md](/Users/cristianopistorio/Code/GitHub/EuniGraph/docs/embeddings.md) for the provider-based embeddings layer and Qdrant integration.
+See [docs/semantic-graph.md](/Users/cristianopistorio/Code/GitHub/EuniGraph/docs/semantic-graph.md) for the materialized semantic similarity graph pipeline.

--- a/backend/migrations/versions/20260414_0005_semantic_graph_builds.py
+++ b/backend/migrations/versions/20260414_0005_semantic_graph_builds.py
@@ -1,0 +1,92 @@
+"""Add semantic graph build tracking table.
+
+Revision ID: 20260414_0005
+Revises: 20260414_0004
+Create Date: 2026-04-14 00:05:00.000000
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "20260414_0005"
+down_revision = "20260414_0004"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "semantic_graph_build",
+        sa.Column(
+            "graph_type",
+            sa.String(length=64),
+            server_default=sa.text("'semantic_similarity'"),
+            nullable=False,
+        ),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column(
+            "started_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("triggered_by", sa.String(length=100), nullable=True),
+        sa.Column("build_params", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("data_snapshot", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("artifact_paths", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("graph_version", sa.String(length=64), nullable=True),
+        sa.Column("node_count", sa.Integer(), nullable=True),
+        sa.Column("edge_count", sa.Integer(), nullable=True),
+        sa.Column("component_count", sa.Integer(), nullable=True),
+        sa.Column("community_count", sa.Integer(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_semantic_graph_build")),
+    )
+    op.create_index(
+        "ix_semantic_graph_build_status",
+        "semantic_graph_build",
+        ["status"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_semantic_graph_build_active",
+        "semantic_graph_build",
+        ["graph_type", "is_active"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_semantic_graph_build_started_at",
+        "semantic_graph_build",
+        ["started_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_semantic_graph_build_started_at", table_name="semantic_graph_build")
+    op.drop_index("ix_semantic_graph_build_active", table_name="semantic_graph_build")
+    op.drop_index("ix_semantic_graph_build_status", table_name="semantic_graph_build")
+    op.drop_table("semantic_graph_build")

--- a/backend/src/eunigraph/api/router.py
+++ b/backend/src/eunigraph/api/router.py
@@ -10,6 +10,7 @@ from eunigraph.api.routers.normalization import router as normalization_router
 from eunigraph.api.routers.organizations import router as organizations_router
 from eunigraph.api.routers.publications import router as publications_router
 from eunigraph.api.routers.researchers import router as researchers_router
+from eunigraph.api.routers.semantic_graph import router as semantic_graph_router
 from eunigraph.api.routers.source_records import router as source_records_router
 
 api_router = APIRouter()
@@ -19,6 +20,7 @@ api_router.include_router(researchers_router)
 api_router.include_router(organizations_router)
 api_router.include_router(source_records_router)
 api_router.include_router(coauthorship_router)
+api_router.include_router(semantic_graph_router)
 api_router.include_router(embeddings_router)
 api_router.include_router(admin_router)
 api_router.include_router(normalization_router)

--- a/backend/src/eunigraph/api/routers/semantic_graph.py
+++ b/backend/src/eunigraph/api/routers/semantic_graph.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import FileResponse
+from sqlalchemy.orm import Session
+
+from eunigraph.api.deps import get_app_settings, get_db_session
+from eunigraph.api.schemas.semantic_graph import (
+    SemanticGraphBuildRequest,
+    SemanticGraphBuildStatusResponse,
+    SemanticGraphMetricsResponse,
+    SemanticGraphNodeMetricsResponse,
+    SemanticGraphPayloadResponse,
+)
+from eunigraph.core.config import Settings
+from eunigraph.modules.semantic_graph.application import SemanticGraphService
+
+router = APIRouter(prefix="/semantic-graph", tags=["semantic-graph"])
+DB_SESSION = Depends(get_db_session)
+APP_SETTINGS = Depends(get_app_settings)
+
+
+def _service(session: Session, settings: Settings) -> SemanticGraphService:
+    return SemanticGraphService(session, settings)
+
+
+@router.post("/build", response_model=SemanticGraphBuildStatusResponse)
+def build_semantic_graph(
+    payload: SemanticGraphBuildRequest,
+    session: Session = DB_SESSION,
+    settings: Settings = APP_SETTINGS,
+) -> SemanticGraphBuildStatusResponse:
+    summary = _service(session, settings).build(
+        triggered_by=payload.triggered_by,
+        top_k=payload.top_k,
+        score_threshold=payload.score_threshold,
+        edge_symmetry_policy=payload.edge_symmetry_policy,
+        mutual_knn=payload.mutual_knn,
+        include_isolated_nodes=payload.include_isolated_nodes,
+        publication_type=payload.publication_type,
+        language_code=payload.language_code,
+        year_from=payload.year_from,
+        year_to=payload.year_to,
+    )
+    return SemanticGraphBuildStatusResponse(**asdict(summary))
+
+
+@router.get("/status", response_model=SemanticGraphBuildStatusResponse)
+def get_semantic_graph_status(
+    session: Session = DB_SESSION,
+    settings: Settings = APP_SETTINGS,
+) -> SemanticGraphBuildStatusResponse:
+    return SemanticGraphBuildStatusResponse(**asdict(_service(session, settings).get_status()))
+
+
+@router.get("", response_model=SemanticGraphPayloadResponse)
+def get_semantic_graph(
+    session: Session = DB_SESSION,
+    settings: Settings = APP_SETTINGS,
+) -> SemanticGraphPayloadResponse:
+    return SemanticGraphPayloadResponse(**_service(session, settings).get_graph())
+
+
+@router.get("/subgraph", response_model=SemanticGraphPayloadResponse)
+def get_semantic_subgraph(
+    publication_id: UUID | None = None,
+    organization_id: UUID | None = None,
+    publication_year: int | None = None,
+    max_nodes: int | None = None,
+    min_edge_weight: float | None = None,
+    community_id: int | None = None,
+    session: Session = DB_SESSION,
+    settings: Settings = APP_SETTINGS,
+) -> SemanticGraphPayloadResponse:
+    payload = _service(session, settings).get_subgraph(
+        publication_id=publication_id,
+        organization_id=organization_id,
+        publication_year=publication_year,
+        max_nodes=max_nodes,
+        min_edge_weight=min_edge_weight,
+        community_id=community_id,
+    )
+    return SemanticGraphPayloadResponse(**payload)
+
+
+@router.get("/metrics", response_model=SemanticGraphMetricsResponse)
+def get_semantic_metrics(
+    session: Session = DB_SESSION,
+    settings: Settings = APP_SETTINGS,
+) -> SemanticGraphMetricsResponse:
+    return SemanticGraphMetricsResponse(**_service(session, settings).get_metrics())
+
+
+@router.get("/nodes/{publication_id}", response_model=SemanticGraphNodeMetricsResponse)
+def get_semantic_node_metrics(
+    publication_id: UUID,
+    session: Session = DB_SESSION,
+    settings: Settings = APP_SETTINGS,
+) -> SemanticGraphNodeMetricsResponse:
+    return SemanticGraphNodeMetricsResponse(
+        **_service(session, settings).get_node_metrics(publication_id),
+    )
+
+
+@router.get("/visualization")
+def get_semantic_visualization(
+    session: Session = DB_SESSION,
+    settings: Settings = APP_SETTINGS,
+) -> FileResponse:
+    visualization_path = _service(session, settings).get_visualization_path()
+    return FileResponse(
+        visualization_path,
+        media_type="image/svg+xml",
+        filename=visualization_path.name,
+    )

--- a/backend/src/eunigraph/api/schemas/semantic_graph.py
+++ b/backend/src/eunigraph/api/schemas/semantic_graph.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class SemanticGraphBuildRequest(BaseModel):
+    triggered_by: str | None = Field(default=None, max_length=100)
+    top_k: int = Field(default=5, ge=1, le=50)
+    score_threshold: float | None = 0.75
+    edge_symmetry_policy: str = Field(default="max_score_union", max_length=64)
+    mutual_knn: bool = False
+    include_isolated_nodes: bool = False
+    publication_type: str | None = Field(default=None, max_length=64)
+    language_code: str | None = Field(default=None, max_length=16)
+    year_from: int | None = None
+    year_to: int | None = None
+
+
+class SemanticGraphBuildStatusResponse(BaseModel):
+    build_id: UUID | None
+    graph_type: str
+    status: str
+    started_at: datetime | None
+    completed_at: datetime | None
+    triggered_by: str | None
+    is_active: bool
+    node_count: int | None
+    edge_count: int | None
+    component_count: int | None
+    community_count: int | None
+    graph_version: str | None
+    artifact_paths: dict[str, str] | None
+    build_params: dict[str, Any] | None
+    data_snapshot: dict[str, Any] | None
+    error_message: str | None
+    latest_successful_build_id: UUID | None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class SemanticGraphNodeResponse(BaseModel):
+    id: str
+    label: str
+    title: str
+    normalized_title: str
+    publication_year: int | None
+    doi: str | None
+    openaire_id: str | None
+    publication_type: str | None
+    language_code: str | None
+    journal_name: str | None
+    venue_name: str | None
+    authors: list[str]
+    organization_ids: list[str]
+    organization_names: list[str]
+    degree: int
+    strength: float
+    betweenness: float
+    component_id: int | None
+    community_id: int | None
+
+
+class SemanticGraphEdgeResponse(BaseModel):
+    source: str
+    target: str
+    weight: float
+    similarity_score: float
+    rank: int
+    mutual_match: bool
+    source_rank: int | None
+    target_rank: int | None
+    source_score: float | None
+    target_score: float | None
+
+
+class SemanticGraphPayloadResponse(BaseModel):
+    build_id: str | None
+    graph_type: str
+    generated_at: datetime
+    summary: dict[str, Any]
+    nodes: list[SemanticGraphNodeResponse]
+    edges: list[SemanticGraphEdgeResponse]
+    data_snapshot: dict[str, Any]
+
+
+class SemanticGraphMetricsResponse(BaseModel):
+    build_id: str | None
+    graph_version: str
+    node_count: int
+    edge_count: int
+    component_count: int
+    community_count: int | None
+    top_degree_nodes: list[SemanticGraphNodeResponse]
+    top_strength_nodes: list[SemanticGraphNodeResponse]
+    top_betweenness_nodes: list[SemanticGraphNodeResponse]
+
+
+class SemanticGraphNodeMetricsNeighborResponse(BaseModel):
+    publication_id: str
+    weight: float
+    similarity_score: float
+    rank: int
+    mutual_match: bool
+
+
+class SemanticGraphNodeMetricsResponse(BaseModel):
+    build_id: str | None
+    node: SemanticGraphNodeResponse
+    incident_edges: list[SemanticGraphEdgeResponse]
+    neighbors: list[SemanticGraphNodeMetricsNeighborResponse]

--- a/backend/src/eunigraph/core/config.py
+++ b/backend/src/eunigraph/core/config.py
@@ -53,6 +53,10 @@ class Settings(BaseSettings):
         default=Path("./data/graphs/coauthorship"),
         alias="EUNIGRAPH_COAUTHORSHIP_GRAPH_STORAGE_PATH",
     )
+    semantic_graph_storage_path: Path = Field(
+        default=Path("./data/graphs/semantic"),
+        alias="EUNIGRAPH_SEMANTIC_GRAPH_STORAGE_PATH",
+    )
 
     model_config = SettingsConfigDict(
         env_file=(".env", "../.env"),
@@ -108,6 +112,10 @@ class Settings(BaseSettings):
         if not self.coauthorship_graph_storage_path.is_absolute():
             self.coauthorship_graph_storage_path = (
                 repo_root / self.coauthorship_graph_storage_path
+            ).resolve()
+        if not self.semantic_graph_storage_path.is_absolute():
+            self.semantic_graph_storage_path = (
+                repo_root / self.semantic_graph_storage_path
             ).resolve()
 
 

--- a/backend/src/eunigraph/modules/embeddings/infrastructure/vector_store.py
+++ b/backend/src/eunigraph/modules/embeddings/infrastructure/vector_store.py
@@ -58,6 +58,49 @@ class QdrantPublicationEmbeddingStore:
             "status": getattr(collection_info, "status", None),
         }
 
+    def get_collection_distance(self, collection_name: str) -> str | None:
+        if not self.client.collection_exists(collection_name):
+            return None
+        collection_info = self.client.get_collection(collection_name)
+        vectors = getattr(getattr(collection_info, "config", None), "params", None)
+        vectors = getattr(vectors, "vectors", None)
+        distance = getattr(vectors, "distance", None)
+        if distance is None and isinstance(vectors, dict):
+            distance = vectors.get("distance")
+        if distance is None:
+            return None
+        return getattr(distance, "value", str(distance))
+
+    def query_similar_publications(
+        self,
+        *,
+        collection_name: str,
+        point_id: str,
+        limit: int,
+        score_threshold: float | None,
+    ) -> list[dict[str, Any]]:
+        response = self.client.query_points(
+            collection_name=collection_name,
+            query=point_id,
+            limit=limit,
+            with_payload=True,
+            with_vectors=False,
+            score_threshold=score_threshold,
+        )
+        results: list[dict[str, Any]] = []
+        for point in getattr(response, "points", []) or []:
+            score = getattr(point, "score", None)
+            if score is None:
+                continue
+            results.append(
+                {
+                    "point_id": str(point.id),
+                    "score": float(score),
+                    "payload": point.payload or {},
+                },
+            )
+        return results
+
     def delete_collection(self, collection_name: str) -> bool:
         if not self.client.collection_exists(collection_name):
             return False

--- a/backend/src/eunigraph/modules/semantic_graph/__init__.py
+++ b/backend/src/eunigraph/modules/semantic_graph/__init__.py
@@ -1,0 +1,1 @@
+"""Semantic graph module."""

--- a/backend/src/eunigraph/modules/semantic_graph/application/__init__.py
+++ b/backend/src/eunigraph/modules/semantic_graph/application/__init__.py
@@ -1,0 +1,21 @@
+"""Semantic graph application services."""
+
+from eunigraph.modules.semantic_graph.application.services import (
+    BUILD_STATUS_COMPLETED,
+    BUILD_STATUS_FAILED,
+    BUILD_STATUS_NOT_BUILT,
+    BUILD_STATUS_RUNNING,
+    GRAPH_TYPE,
+    SemanticGraphBuildSummary,
+    SemanticGraphService,
+)
+
+__all__ = [
+    "BUILD_STATUS_COMPLETED",
+    "BUILD_STATUS_FAILED",
+    "BUILD_STATUS_NOT_BUILT",
+    "BUILD_STATUS_RUNNING",
+    "GRAPH_TYPE",
+    "SemanticGraphBuildSummary",
+    "SemanticGraphService",
+]

--- a/backend/src/eunigraph/modules/semantic_graph/application/services.py
+++ b/backend/src/eunigraph/modules/semantic_graph/application/services.py
@@ -1,0 +1,1116 @@
+from __future__ import annotations
+
+import hashlib
+import importlib
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, cast
+from uuid import UUID
+
+from fastapi import HTTPException, status
+from sqlalchemy import Select, func, select, update
+from sqlalchemy.orm import Session, selectinload
+
+from eunigraph.core.config import Settings
+from eunigraph.modules.catalog.infrastructure.models import (
+    PublicationAuthorModel,
+    PublicationModel,
+    PublicationOrganizationModel,
+)
+from eunigraph.modules.embeddings.infrastructure import (
+    PublicationEmbeddingModel,
+    QdrantPublicationEmbeddingStore,
+)
+from eunigraph.modules.semantic_graph.infrastructure.models import SemanticGraphBuildModel
+from eunigraph.persistence.qdrant.client import get_qdrant_client
+
+GRAPH_TYPE = "semantic_similarity"
+BUILD_STATUS_COMPLETED = "completed"
+BUILD_STATUS_FAILED = "failed"
+BUILD_STATUS_NOT_BUILT = "not_built"
+BUILD_STATUS_RUNNING = "running"
+SUPPORTED_EDGE_SYMMETRY_POLICIES = {"max_score_union", "mutual_only"}
+
+
+@dataclass(slots=True)
+class SemanticGraphBuildSummary:
+    build_id: UUID | None
+    graph_type: str
+    status: str
+    started_at: datetime | None
+    completed_at: datetime | None
+    triggered_by: str | None
+    is_active: bool
+    node_count: int | None
+    edge_count: int | None
+    component_count: int | None
+    community_count: int | None
+    graph_version: str | None
+    artifact_paths: dict[str, str] | None
+    build_params: dict[str, Any] | None
+    data_snapshot: dict[str, Any] | None
+    error_message: str | None
+    latest_successful_build_id: UUID | None
+
+
+class SemanticGraphService:
+    def __init__(
+        self,
+        session: Session,
+        settings: Settings,
+        *,
+        vector_store: QdrantPublicationEmbeddingStore | None = None,
+    ) -> None:
+        self.session = session
+        self.settings = settings
+        self.storage_path = settings.semantic_graph_storage_path
+        self._vector_store = vector_store
+
+    def build(
+        self,
+        *,
+        triggered_by: str | None = None,
+        top_k: int = 5,
+        score_threshold: float | None = 0.75,
+        edge_symmetry_policy: str = "max_score_union",
+        mutual_knn: bool = False,
+        include_isolated_nodes: bool = False,
+        publication_type: str | None = None,
+        language_code: str | None = None,
+        year_from: int | None = None,
+        year_to: int | None = None,
+    ) -> SemanticGraphBuildSummary:
+        self._validate_build_params(
+            top_k=top_k,
+            edge_symmetry_policy=edge_symmetry_policy,
+            year_from=year_from,
+            year_to=year_to,
+        )
+        build = SemanticGraphBuildModel(
+            graph_type=GRAPH_TYPE,
+            status=BUILD_STATUS_RUNNING,
+            triggered_by=triggered_by or "api",
+            build_params={
+                "top_k": top_k,
+                "score_threshold": score_threshold,
+                "edge_symmetry_policy": edge_symmetry_policy,
+                "mutual_knn": mutual_knn,
+                "include_isolated_nodes": include_isolated_nodes,
+                "publication_type": publication_type,
+                "language_code": language_code,
+                "year_from": year_from,
+                "year_to": year_to,
+                "qdrant_collection": self.settings.qdrant_collection_publications,
+                "embedding_provider": self.settings.embeddings_provider,
+                "embedding_model": self.settings.embeddings_model,
+                "embedding_version": self.settings.embeddings_version,
+                "weight_strategy": "qdrant_score",
+            },
+            is_active=False,
+        )
+        self.session.add(build)
+        self.session.commit()
+        self.session.refresh(build)
+
+        try:
+            self.storage_path.mkdir(parents=True, exist_ok=True)
+            payload, graph, snapshot, resolved_build_params = self._build_materialized_graph(
+                top_k=top_k,
+                score_threshold=score_threshold,
+                edge_symmetry_policy=edge_symmetry_policy,
+                mutual_knn=mutual_knn,
+                include_isolated_nodes=include_isolated_nodes,
+                publication_type=publication_type,
+                language_code=language_code,
+                year_from=year_from,
+                year_to=year_to,
+            )
+            artifact_dir = self._artifact_directory(build.id)
+            artifact_dir.mkdir(parents=True, exist_ok=True)
+            artifact_paths = self._write_artifacts(
+                build_id=build.id,
+                graph=graph,
+                payload=payload,
+                artifact_dir=artifact_dir,
+            )
+
+            build.status = BUILD_STATUS_COMPLETED
+            build.completed_at = datetime.now(UTC)
+            build.is_active = True
+            build.node_count = int(payload["summary"]["node_count"])
+            build.edge_count = int(payload["summary"]["edge_count"])
+            build.component_count = int(payload["summary"]["component_count"])
+            build.community_count = payload["summary"]["community_count"]
+            build.graph_version = str(payload["summary"]["graph_version"])
+            build.artifact_paths = artifact_paths
+            build.data_snapshot = snapshot
+            build.build_params = resolved_build_params
+            build.error_message = None
+
+            self.session.execute(
+                update(SemanticGraphBuildModel)
+                .where(
+                    SemanticGraphBuildModel.graph_type == GRAPH_TYPE,
+                    SemanticGraphBuildModel.id != build.id,
+                    SemanticGraphBuildModel.is_active.is_(True),
+                )
+                .values(is_active=False)
+            )
+            self.session.commit()
+            self.session.refresh(build)
+            return self._to_summary(build)
+        except Exception as exc:
+            self.session.rollback()
+            failed_build = self.session.get(SemanticGraphBuildModel, build.id)
+            if failed_build is None:
+                raise
+            failed_build.status = BUILD_STATUS_FAILED
+            failed_build.completed_at = datetime.now(UTC)
+            failed_build.error_message = str(exc)
+            failed_build.is_active = False
+            self.session.commit()
+            self.session.refresh(failed_build)
+            return self._to_summary(failed_build)
+
+    def get_status(self) -> SemanticGraphBuildSummary:
+        build = self._latest_build()
+        if build is None:
+            return SemanticGraphBuildSummary(
+                build_id=None,
+                graph_type=GRAPH_TYPE,
+                status=BUILD_STATUS_NOT_BUILT,
+                started_at=None,
+                completed_at=None,
+                triggered_by=None,
+                is_active=False,
+                node_count=None,
+                edge_count=None,
+                component_count=None,
+                community_count=None,
+                graph_version=None,
+                artifact_paths=None,
+                build_params=None,
+                data_snapshot=None,
+                error_message=None,
+                latest_successful_build_id=None,
+            )
+        return self._to_summary(build)
+
+    def get_graph(self) -> dict[str, Any]:
+        return self._load_materialized_payload()
+
+    def get_subgraph(
+        self,
+        *,
+        publication_id: UUID | None = None,
+        organization_id: UUID | None = None,
+        publication_year: int | None = None,
+        max_nodes: int | None = None,
+        min_edge_weight: float | None = None,
+        community_id: int | None = None,
+    ) -> dict[str, Any]:
+        payload = self._load_materialized_payload()
+        return self._filter_subgraph(
+            payload,
+            publication_id=publication_id,
+            organization_id=organization_id,
+            publication_year=publication_year,
+            max_nodes=max_nodes,
+            min_edge_weight=min_edge_weight,
+            community_id=community_id,
+        )
+
+    def get_metrics(self) -> dict[str, Any]:
+        payload = self._load_materialized_payload()
+        nodes = list(payload["nodes"])
+        return {
+            "build_id": payload["build_id"],
+            "graph_version": payload["summary"]["graph_version"],
+            "node_count": payload["summary"]["node_count"],
+            "edge_count": payload["summary"]["edge_count"],
+            "component_count": payload["summary"]["component_count"],
+            "community_count": payload["summary"]["community_count"],
+            "top_degree_nodes": sorted(
+                nodes,
+                key=lambda node: (node["degree"], node["strength"], node["label"]),
+                reverse=True,
+            )[:10],
+            "top_strength_nodes": sorted(
+                nodes,
+                key=lambda node: (node["strength"], node["degree"], node["label"]),
+                reverse=True,
+            )[:10],
+            "top_betweenness_nodes": sorted(
+                nodes,
+                key=lambda node: (node["betweenness"], node["strength"], node["label"]),
+                reverse=True,
+            )[:10],
+        }
+
+    def get_node_metrics(self, publication_id: UUID) -> dict[str, Any]:
+        payload = self._load_materialized_payload()
+        publication_id_str = str(publication_id)
+        node = next((item for item in payload["nodes"] if item["id"] == publication_id_str), None)
+        if node is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Publication node not found in the active semantic graph",
+            )
+        incident_edges = [
+            edge
+            for edge in payload["edges"]
+            if edge["source"] == publication_id_str or edge["target"] == publication_id_str
+        ]
+        neighbors = sorted(
+            (
+                {
+                    "publication_id": (
+                        edge["target"] if edge["source"] == publication_id_str else edge["source"]
+                    ),
+                    "weight": edge["weight"],
+                    "similarity_score": edge["similarity_score"],
+                    "rank": edge["rank"],
+                    "mutual_match": edge["mutual_match"],
+                }
+                for edge in incident_edges
+            ),
+            key=lambda item: (item["weight"], item["mutual_match"], -item["rank"]),
+            reverse=True,
+        )
+        return {
+            "build_id": payload["build_id"],
+            "node": node,
+            "incident_edges": incident_edges,
+            "neighbors": neighbors,
+        }
+
+    def get_visualization_path(self) -> Path:
+        build = self._latest_successful_build_or_404()
+        if build.artifact_paths is None or "visualization" not in build.artifact_paths:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="No semantic graph visualization is available",
+            )
+        visualization_path = Path(build.artifact_paths["visualization"])
+        if not visualization_path.exists():
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="The persisted semantic graph visualization file is missing",
+            )
+        return visualization_path
+
+    def _validate_build_params(
+        self,
+        *,
+        top_k: int,
+        edge_symmetry_policy: str,
+        year_from: int | None,
+        year_to: int | None,
+    ) -> None:
+        if top_k < 1:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="`top_k` must be greater than or equal to 1",
+            )
+        if edge_symmetry_policy not in SUPPORTED_EDGE_SYMMETRY_POLICIES:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"Unsupported edge symmetry policy `{edge_symmetry_policy}`. "
+                    f"Supported values: {', '.join(sorted(SUPPORTED_EDGE_SYMMETRY_POLICIES))}"
+                ),
+            )
+        if year_from is not None and year_to is not None and year_from > year_to:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="`year_from` cannot be greater than `year_to`",
+            )
+
+    def _vector_store_instance(self) -> QdrantPublicationEmbeddingStore:
+        if self._vector_store is not None:
+            return self._vector_store
+        self._vector_store = QdrantPublicationEmbeddingStore(get_qdrant_client())
+        return self._vector_store
+
+    def _latest_build(self) -> SemanticGraphBuildModel | None:
+        query: Select[tuple[SemanticGraphBuildModel]] = (
+            select(SemanticGraphBuildModel)
+            .where(SemanticGraphBuildModel.graph_type == GRAPH_TYPE)
+            .order_by(SemanticGraphBuildModel.started_at.desc())
+        )
+        return self.session.scalars(query).first()
+
+    def _latest_successful_build(self) -> SemanticGraphBuildModel | None:
+        query: Select[tuple[SemanticGraphBuildModel]] = (
+            select(SemanticGraphBuildModel)
+            .where(
+                SemanticGraphBuildModel.graph_type == GRAPH_TYPE,
+                SemanticGraphBuildModel.status == BUILD_STATUS_COMPLETED,
+                SemanticGraphBuildModel.is_active.is_(True),
+            )
+            .order_by(SemanticGraphBuildModel.started_at.desc())
+        )
+        build = self.session.scalars(query).first()
+        if build is not None:
+            return build
+        fallback_query: Select[tuple[SemanticGraphBuildModel]] = (
+            select(SemanticGraphBuildModel)
+            .where(
+                SemanticGraphBuildModel.graph_type == GRAPH_TYPE,
+                SemanticGraphBuildModel.status == BUILD_STATUS_COMPLETED,
+            )
+            .order_by(SemanticGraphBuildModel.started_at.desc())
+        )
+        return self.session.scalars(fallback_query).first()
+
+    def _latest_successful_build_or_404(self) -> SemanticGraphBuildModel:
+        build = self._latest_successful_build()
+        if build is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="No completed semantic graph build is available",
+            )
+        return build
+
+    def _to_summary(self, build: SemanticGraphBuildModel) -> SemanticGraphBuildSummary:
+        latest_successful_build = self._latest_successful_build()
+        return SemanticGraphBuildSummary(
+            build_id=build.id,
+            graph_type=build.graph_type,
+            status=build.status,
+            started_at=build.started_at,
+            completed_at=build.completed_at,
+            triggered_by=build.triggered_by,
+            is_active=build.is_active,
+            node_count=build.node_count,
+            edge_count=build.edge_count,
+            component_count=build.component_count,
+            community_count=build.community_count,
+            graph_version=build.graph_version,
+            artifact_paths=build.artifact_paths,
+            build_params=build.build_params,
+            data_snapshot=build.data_snapshot,
+            error_message=build.error_message,
+            latest_successful_build_id=(
+                latest_successful_build.id if latest_successful_build is not None else None
+            ),
+        )
+
+    def _artifact_directory(self, build_id: UUID) -> Path:
+        timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+        return self.storage_path / f"{timestamp}_{build_id}"
+
+    def _load_materialized_payload(self) -> dict[str, Any]:
+        build = self._latest_successful_build_or_404()
+        if build.artifact_paths is None or "api_payload" not in build.artifact_paths:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="No materialized semantic graph payload is available",
+            )
+        payload_path = Path(build.artifact_paths["api_payload"])
+        if not payload_path.exists():
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="The persisted semantic graph payload file is missing",
+            )
+        return json.loads(payload_path.read_text(encoding="utf-8"))
+
+    def _build_materialized_graph(
+        self,
+        *,
+        top_k: int,
+        score_threshold: float | None,
+        edge_symmetry_policy: str,
+        mutual_knn: bool,
+        include_isolated_nodes: bool,
+        publication_type: str | None,
+        language_code: str | None,
+        year_from: int | None,
+        year_to: int | None,
+    ) -> tuple[dict[str, Any], Any, dict[str, Any], dict[str, Any]]:
+        publications = self._select_publications_with_embeddings(
+            publication_type=publication_type,
+            language_code=language_code,
+            year_from=year_from,
+            year_to=year_to,
+        )
+        collection_status = self._vector_store_instance().get_collection_status(
+            self.settings.qdrant_collection_publications,
+        )
+        if publications and not collection_status["exists"]:
+            raise RuntimeError(
+                "Configured Qdrant collection "
+                f"`{self.settings.qdrant_collection_publications}` is missing",
+            )
+        qdrant_distance = self._vector_store_instance().get_collection_distance(
+            self.settings.qdrant_collection_publications,
+        )
+        node_map, edge_map = self._collect_graph_inputs(
+            publications=publications,
+            top_k=top_k,
+            score_threshold=score_threshold,
+            mutual_knn=mutual_knn,
+            edge_symmetry_policy=edge_symmetry_policy,
+            include_isolated_nodes=include_isolated_nodes,
+        )
+        nodes = sorted(node_map.values(), key=lambda node: (node["label"], node["id"]))
+        edges = sorted(edge_map.values(), key=lambda edge: (edge["source"], edge["target"]))
+        graph, node_metrics, component_count, community_count = self._analyze_graph(nodes, edges)
+
+        for node in nodes:
+            metrics = node_metrics[node["id"]]
+            node["degree"] = metrics["degree"]
+            node["strength"] = metrics["strength"]
+            node["betweenness"] = metrics["betweenness"]
+            node["component_id"] = metrics["component_id"]
+            node["community_id"] = metrics["community_id"]
+
+        graph_version = self._compute_graph_version(
+            nodes=nodes,
+            edges=edges,
+            build_params={
+                "top_k": top_k,
+                "score_threshold": score_threshold,
+                "edge_symmetry_policy": edge_symmetry_policy,
+                "mutual_knn": mutual_knn,
+                "qdrant_distance": qdrant_distance,
+            },
+        )
+        snapshot = self._build_data_snapshot(publication_count=len(publications))
+        resolved_build_params = {
+            "qdrant_collection": self.settings.qdrant_collection_publications,
+            "qdrant_distance": qdrant_distance,
+            "top_k": top_k,
+            "score_threshold": score_threshold,
+            "edge_symmetry_policy": edge_symmetry_policy,
+            "mutual_knn": mutual_knn,
+            "weight_strategy": "qdrant_score",
+            "include_isolated_nodes": include_isolated_nodes,
+            "publication_type": publication_type,
+            "language_code": language_code,
+            "year_from": year_from,
+            "year_to": year_to,
+            "embedding_provider": self.settings.embeddings_provider,
+            "embedding_model": self.settings.embeddings_model,
+            "embedding_version": self.settings.embeddings_version,
+        }
+        payload = {
+            "build_id": None,
+            "graph_type": GRAPH_TYPE,
+            "generated_at": datetime.now(UTC).isoformat(),
+            "summary": {
+                "node_count": len(nodes),
+                "edge_count": len(edges),
+                "component_count": component_count,
+                "community_count": community_count,
+                "graph_version": graph_version,
+            },
+            "nodes": nodes,
+            "edges": edges,
+            "data_snapshot": snapshot,
+        }
+        return payload, graph, snapshot, resolved_build_params
+
+    def _select_publications_with_embeddings(
+        self,
+        *,
+        publication_type: str | None,
+        language_code: str | None,
+        year_from: int | None,
+        year_to: int | None,
+    ) -> list[PublicationModel]:
+        query: Select[tuple[PublicationModel]] = (
+            select(PublicationModel)
+            .join(PublicationModel.embeddings)
+            .options(
+                selectinload(PublicationModel.embeddings),
+                selectinload(PublicationModel.authors).selectinload(
+                    PublicationAuthorModel.researcher,
+                ),
+                selectinload(PublicationModel.organizations).selectinload(
+                    PublicationOrganizationModel.organization,
+                ),
+            )
+            .where(
+                PublicationEmbeddingModel.embedding_provider == self.settings.embeddings_provider,
+                PublicationEmbeddingModel.embedding_model == self.settings.embeddings_model,
+                PublicationEmbeddingModel.embedding_version == self.settings.embeddings_version,
+                PublicationEmbeddingModel.qdrant_collection
+                == self.settings.qdrant_collection_publications,
+            )
+            .order_by(PublicationModel.created_at.desc())
+        )
+        if publication_type is not None:
+            query = query.where(PublicationModel.publication_type == publication_type)
+        if language_code is not None:
+            query = query.where(PublicationModel.language_code == language_code)
+        if year_from is not None:
+            query = query.where(PublicationModel.publication_year >= year_from)
+        if year_to is not None:
+            query = query.where(PublicationModel.publication_year <= year_to)
+        return list(self.session.scalars(query).unique())
+
+    def _collect_graph_inputs(
+        self,
+        *,
+        publications: list[PublicationModel],
+        top_k: int,
+        score_threshold: float | None,
+        mutual_knn: bool,
+        edge_symmetry_policy: str,
+        include_isolated_nodes: bool,
+    ) -> tuple[dict[str, dict[str, Any]], dict[tuple[str, str], dict[str, Any]]]:
+        node_map: dict[str, dict[str, Any]] = {}
+        point_id_to_publication_id: dict[str, str] = {}
+        for publication in publications:
+            publication_id = str(publication.id)
+            node_map[publication_id] = {
+                "id": publication_id,
+                "label": self._publication_label(publication.title),
+                "title": publication.title,
+                "normalized_title": publication.normalized_title,
+                "publication_year": self._publication_year(publication),
+                "doi": publication.doi,
+                "openaire_id": publication.openaire_id,
+                "publication_type": publication.publication_type,
+                "language_code": publication.language_code,
+                "journal_name": publication.journal_name,
+                "venue_name": publication.venue_name,
+                "authors": self._publication_author_names(publication),
+                "organization_ids": self._publication_organization_ids(publication),
+                "organization_names": self._publication_organization_names(publication),
+            }
+            embedding = self._matching_embedding(publication)
+            if embedding is not None:
+                point_id_to_publication_id[embedding.qdrant_point_id] = publication_id
+
+        directional_edges: dict[tuple[str, str], dict[str, Any]] = {}
+        query_limit = max((top_k * 4), top_k + 10)
+        for publication in publications:
+            source_embedding = self._matching_embedding(publication)
+            if source_embedding is None:
+                continue
+            source_id = str(publication.id)
+            neighbor_hits = self._vector_store_instance().query_similar_publications(
+                collection_name=self.settings.qdrant_collection_publications,
+                point_id=source_embedding.qdrant_point_id,
+                limit=query_limit,
+                score_threshold=score_threshold,
+            )
+            accepted_count = 0
+            for hit in neighbor_hits:
+                target_id = self._target_publication_id(
+                    point_id=str(hit["point_id"]),
+                    payload=cast(dict[str, Any], hit["payload"]),
+                    point_id_to_publication_id=point_id_to_publication_id,
+                )
+                if target_id is None or target_id == source_id or target_id not in node_map:
+                    continue
+                accepted_count += 1
+                directional_edges[(source_id, target_id)] = {
+                    "source": source_id,
+                    "target": target_id,
+                    "score": float(hit["score"]),
+                    "rank": accepted_count,
+                }
+                if accepted_count >= top_k:
+                    break
+
+        edge_map: dict[tuple[str, str], dict[str, Any]] = {}
+        for source_id, target_id in directional_edges:
+            pair = (
+                source_id if source_id < target_id else target_id,
+                target_id if source_id < target_id else source_id,
+            )
+            if pair in edge_map:
+                continue
+            left_to_right = directional_edges.get((pair[0], pair[1]))
+            right_to_left = directional_edges.get((pair[1], pair[0]))
+            mutual_match = left_to_right is not None and right_to_left is not None
+            if mutual_knn or edge_symmetry_policy == "mutual_only":
+                if not mutual_match:
+                    continue
+            candidate_edges = [edge for edge in (left_to_right, right_to_left) if edge is not None]
+            best_edge = max(candidate_edges, key=lambda edge: (edge["score"], -edge["rank"]))
+            rank_values = [edge["rank"] for edge in candidate_edges]
+            edge_map[pair] = {
+                "source": pair[0],
+                "target": pair[1],
+                "weight": float(best_edge["score"]),
+                "similarity_score": float(best_edge["score"]),
+                "rank": min(rank_values),
+                "mutual_match": mutual_match,
+                "source_rank": left_to_right["rank"] if left_to_right is not None else None,
+                "target_rank": right_to_left["rank"] if right_to_left is not None else None,
+                "source_score": (
+                    float(left_to_right["score"]) if left_to_right is not None else None
+                ),
+                "target_score": (
+                    float(right_to_left["score"]) if right_to_left is not None else None
+                ),
+            }
+
+        if not include_isolated_nodes:
+            connected_node_ids = {
+                node_id
+                for edge in edge_map.values()
+                for node_id in (edge["source"], edge["target"])
+            }
+            node_map = {
+                node_id: node
+                for node_id, node in node_map.items()
+                if node_id in connected_node_ids
+            }
+        return node_map, edge_map
+
+    def _analyze_graph(
+        self,
+        nodes: list[dict[str, Any]],
+        edges: list[dict[str, Any]],
+    ) -> tuple[Any, dict[str, dict[str, int | float | None]], int, int | None]:
+        graph_tool = self._load_graph_tool()
+        graph = graph_tool["Graph"](directed=False)
+        graph.add_vertex(len(nodes))
+
+        vertex_index_by_node_id: dict[str, int] = {}
+        publication_id_property = graph.new_vertex_property("string")
+        label_property = graph.new_vertex_property("string")
+        edge_weight_property = graph.new_edge_property("double")
+
+        for index, node in enumerate(nodes):
+            vertex = graph.vertex(index)
+            vertex_index_by_node_id[node["id"]] = index
+            publication_id_property[vertex] = node["id"]
+            label_property[vertex] = node["label"]
+
+        for edge in edges:
+            source_vertex = graph.vertex(vertex_index_by_node_id[edge["source"]])
+            target_vertex = graph.vertex(vertex_index_by_node_id[edge["target"]])
+            graph_edge = graph.add_edge(source_vertex, target_vertex)
+            edge_weight_property[graph_edge] = float(edge["weight"])
+
+        graph.vertex_properties["publication_id"] = publication_id_property
+        graph.vertex_properties["label"] = label_property
+        graph.edge_properties["weight"] = edge_weight_property
+
+        node_metrics: dict[str, dict[str, int | float | None]] = {}
+        if nodes:
+            vertex_betweenness, _ = graph_tool["betweenness"](graph, weight=edge_weight_property)
+            component_labels, component_histogram = graph_tool["label_components"](graph)
+            component_count = int(len(component_histogram))
+            community_ids: dict[int, int] | None = None
+            community_count: int | None = None
+            if graph.num_vertices() > 0 and graph.num_edges() > 0:
+                try:
+                    community_ids = {}
+                    community_state = graph_tool["minimize_blockmodel_dl"](graph)
+                    blocks = community_state.get_blocks()
+                    for index in range(len(nodes)):
+                        community_ids[index] = int(blocks[graph.vertex(index)])
+                    community_count = len(set(community_ids.values()))
+                except Exception:
+                    community_ids = None
+                    community_count = None
+        else:
+            component_count = 0
+            component_labels = None
+            vertex_betweenness = None
+            community_ids = None
+            community_count = 0
+
+        for node in nodes:
+            vertex = graph.vertex(vertex_index_by_node_id[node["id"]])
+            strength = 0.0
+            for edge in vertex.all_edges():
+                strength += float(edge_weight_property[edge])
+            node_metrics[node["id"]] = {
+                "degree": int(vertex.out_degree()),
+                "strength": round(strength, 6),
+                "betweenness": (
+                    float(vertex_betweenness[vertex]) if vertex_betweenness is not None else 0.0
+                ),
+                "component_id": (
+                    int(component_labels[vertex]) if component_labels is not None else None
+                ),
+                "community_id": (
+                    community_ids[vertex_index_by_node_id[node["id"]]]
+                    if community_ids is not None
+                    else None
+                ),
+            }
+
+        return graph, node_metrics, component_count, community_count
+
+    def _write_artifacts(
+        self,
+        *,
+        build_id: UUID,
+        graph: Any,
+        payload: dict[str, Any],
+        artifact_dir: Path,
+    ) -> dict[str, str]:
+        json_path = artifact_dir / "semantic_graph.json"
+        gt_path = artifact_dir / "semantic_graph.gt"
+        svg_path = artifact_dir / "semantic_graph.svg"
+
+        payload["build_id"] = str(build_id)
+        json_path.write_text(
+            json.dumps(payload, ensure_ascii=True, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+        graph.save(str(gt_path))
+        svg_path.write_text(
+            self._render_svg(payload["nodes"], payload["edges"]),
+            encoding="utf-8",
+        )
+        return {
+            "graph": str(gt_path),
+            "api_payload": str(json_path),
+            "visualization": str(svg_path),
+        }
+
+    def _render_svg(self, nodes: list[dict[str, Any]], edges: list[dict[str, Any]]) -> str:
+        width = 1400
+        height = 1000
+        if not nodes:
+            return (
+                f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}">'
+                '<rect width="100%" height="100%" fill="#ffffff" />'
+                '<text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" '
+                'font-family="sans-serif" font-size="28" fill="#333333">'
+                "No semantic graph has been materialized yet"
+                "</text></svg>"
+            )
+
+        sorted_nodes = sorted(
+            nodes,
+            key=lambda node: (-node["strength"], -node["degree"], node["label"]),
+        )
+        palette = [
+            "#0f766e",
+            "#0ea5e9",
+            "#f59e0b",
+            "#ef4444",
+            "#8b5cf6",
+            "#84cc16",
+            "#ec4899",
+        ]
+        positions: dict[str, tuple[float, float]] = {}
+        for node in sorted_nodes:
+            positions[node["id"]] = self._scatter_position(
+                node_id=node["id"],
+                width=width,
+                height=height,
+            )
+
+        edge_elements = []
+        for edge in edges:
+            x1, y1 = positions[edge["source"]]
+            x2, y2 = positions[edge["target"]]
+            stroke_width = 0.3 + min(float(edge["weight"]) * 2.5, 2.8)
+            edge_elements.append(
+                f'<line x1="{x1:.2f}" y1="{y1:.2f}" x2="{x2:.2f}" y2="{y2:.2f}" '
+                f'stroke="#94a3b8" stroke-opacity="0.24" stroke-width="{stroke_width:.2f}" />'
+            )
+
+        node_elements = []
+        for node in sorted_nodes:
+            x, y = positions[node["id"]]
+            component_id = node.get("community_id")
+            if component_id is None:
+                component_id = node.get("component_id", 0)
+            color = palette[int(component_id or 0) % len(palette)]
+            size = 1.7 + min(float(node["strength"]) * 0.55, 4.0)
+            node_elements.append(
+                f'<circle cx="{x:.2f}" cy="{y:.2f}" r="{size:.2f}" fill="{color}" '
+                'stroke="#ffffff" stroke-width="0.6" />'
+            )
+
+        return (
+            f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}">'
+            '<rect width="100%" height="100%" fill="#f8fafc" />'
+            '<g>'
+            + "".join(edge_elements)
+            + "</g><g>"
+            + "".join(node_elements)
+            + "</g></svg>"
+        )
+
+    def _scatter_position(
+        self,
+        *,
+        node_id: str,
+        width: int,
+        height: int,
+    ) -> tuple[float, float]:
+        margin_x = 70
+        margin_y = 70
+        digest = hashlib.sha256(node_id.encode("utf-8")).digest()
+        x_seed = int.from_bytes(digest[:8], byteorder="big")
+        y_seed = int.from_bytes(digest[8:16], byteorder="big")
+        usable_width = width - (margin_x * 2)
+        usable_height = height - (margin_y * 2)
+        x = margin_x + (x_seed / (2**64 - 1)) * usable_width
+        y = margin_y + (y_seed / (2**64 - 1)) * usable_height
+        return (x, y)
+
+    def _compute_graph_version(
+        self,
+        *,
+        nodes: list[dict[str, Any]],
+        edges: list[dict[str, Any]],
+        build_params: dict[str, Any],
+    ) -> str:
+        stable_payload = {
+            "nodes": sorted(
+                (
+                    {
+                        "id": node["id"],
+                        "publication_year": node["publication_year"],
+                        "organization_ids": node["organization_ids"],
+                    }
+                    for node in nodes
+                ),
+                key=lambda node: node["id"],
+            ),
+            "edges": sorted(
+                (
+                    {
+                        "source": edge["source"],
+                        "target": edge["target"],
+                        "weight": edge["weight"],
+                        "rank": edge["rank"],
+                        "mutual_match": edge["mutual_match"],
+                    }
+                    for edge in edges
+                ),
+                key=lambda edge: (edge["source"], edge["target"]),
+            ),
+            "build_params": build_params,
+        }
+        payload_bytes = json.dumps(stable_payload, sort_keys=True).encode("utf-8")
+        return hashlib.sha256(payload_bytes).hexdigest()
+
+    def _build_data_snapshot(self, *, publication_count: int) -> dict[str, Any]:
+        embedding_count, latest_embedding_updated_at = self.session.execute(
+            select(
+                func.count(PublicationEmbeddingModel.id),
+                func.max(PublicationEmbeddingModel.updated_at),
+            ).where(
+                PublicationEmbeddingModel.embedding_provider == self.settings.embeddings_provider,
+                PublicationEmbeddingModel.embedding_model == self.settings.embeddings_model,
+                PublicationEmbeddingModel.embedding_version == self.settings.embeddings_version,
+                PublicationEmbeddingModel.qdrant_collection
+                == self.settings.qdrant_collection_publications,
+            ),
+        ).one()
+        collection_status = self._vector_store_instance().get_collection_status(
+            self.settings.qdrant_collection_publications,
+        )
+        return {
+            "selected_publication_count": publication_count,
+            "active_embedding_count": int(embedding_count or 0),
+            "qdrant_collection_exists": bool(collection_status["exists"]),
+            "qdrant_points_count": int(collection_status["points_count"]),
+            "qdrant_collection_status": collection_status["status"],
+            "latest_embedding_updated_at": self._isoformat_or_none(latest_embedding_updated_at),
+        }
+
+    def _filter_subgraph(
+        self,
+        payload: dict[str, Any],
+        *,
+        publication_id: UUID | None,
+        organization_id: UUID | None,
+        publication_year: int | None,
+        max_nodes: int | None,
+        min_edge_weight: float | None,
+        community_id: int | None,
+    ) -> dict[str, Any]:
+        nodes = list(payload["nodes"])
+        edges = list(payload["edges"])
+        if min_edge_weight is not None:
+            edges = [edge for edge in edges if edge["weight"] >= min_edge_weight]
+
+        selected_node_ids = {node["id"] for node in nodes}
+        if community_id is not None:
+            selected_node_ids = {
+                node["id"] for node in nodes if node.get("community_id") == community_id
+            }
+        if publication_year is not None:
+            selected_node_ids &= {
+                node["id"]
+                for node in nodes
+                if node.get("publication_year") == publication_year
+            }
+        if organization_id is not None:
+            organization_id_str = str(organization_id)
+            selected_node_ids &= {
+                node["id"]
+                for node in nodes
+                if organization_id_str in node.get("organization_ids", [])
+            }
+
+        if publication_id is not None:
+            publication_id_str = str(publication_id)
+            candidate_edges = [
+                edge
+                for edge in edges
+                if publication_id_str in (edge["source"], edge["target"])
+                and edge["source"] in selected_node_ids
+                and edge["target"] in selected_node_ids
+            ]
+            candidate_edges.sort(
+                key=lambda edge: (
+                    edge["weight"],
+                    edge["mutual_match"],
+                    -edge["rank"],
+                    edge["target"],
+                    edge["source"],
+                ),
+                reverse=True,
+            )
+            selected_node_ids = {publication_id_str}
+            for edge in candidate_edges:
+                if max_nodes is not None and len(selected_node_ids) >= max_nodes:
+                    break
+                selected_node_ids.add(edge["source"])
+                if max_nodes is not None and len(selected_node_ids) >= max_nodes:
+                    break
+                selected_node_ids.add(edge["target"])
+        elif max_nodes is not None:
+            ranked_nodes = sorted(
+                (node for node in nodes if node["id"] in selected_node_ids),
+                key=lambda node: (node["strength"], node["degree"], node["label"]),
+                reverse=True,
+            )
+            selected_node_ids = {node["id"] for node in ranked_nodes[:max_nodes]}
+
+        filtered_nodes = [node for node in nodes if node["id"] in selected_node_ids]
+        filtered_edges = [
+            edge
+            for edge in edges
+            if edge["source"] in selected_node_ids and edge["target"] in selected_node_ids
+        ]
+        return {
+            "build_id": payload["build_id"],
+            "graph_type": payload["graph_type"],
+            "generated_at": payload["generated_at"],
+            "summary": {
+                "node_count": len(filtered_nodes),
+                "edge_count": len(filtered_edges),
+                "component_count": len(
+                    {
+                        node["component_id"]
+                        for node in filtered_nodes
+                        if node["component_id"] is not None
+                    }
+                ),
+                "community_count": len(
+                    {
+                        node["community_id"]
+                        for node in filtered_nodes
+                        if node["community_id"] is not None
+                    }
+                )
+                or None,
+                "graph_version": payload["summary"]["graph_version"],
+            },
+            "nodes": filtered_nodes,
+            "edges": filtered_edges,
+            "data_snapshot": payload["data_snapshot"],
+        }
+
+    def _load_graph_tool(self) -> dict[str, Any]:
+        try:
+            graph_tool_module = importlib.import_module("graph_tool")
+            centrality_module = importlib.import_module("graph_tool.centrality")
+            inference_module = importlib.import_module("graph_tool.inference")
+            topology_module = importlib.import_module("graph_tool.topology")
+        except ModuleNotFoundError as exc:
+            raise RuntimeError(
+                "graph-tool is not available in the backend runtime. Rebuild the backend container "
+                "after the graph-tool environment fix before building the semantic graph."
+            ) from exc
+
+        graph_tool_module = cast(Any, graph_tool_module)
+        centrality_module = cast(Any, centrality_module)
+        inference_module = cast(Any, inference_module)
+        topology_module = cast(Any, topology_module)
+        return {
+            "Graph": graph_tool_module.Graph,
+            "betweenness": centrality_module.betweenness,
+            "label_components": topology_module.label_components,
+            "minimize_blockmodel_dl": inference_module.minimize_blockmodel_dl,
+        }
+
+    def _matching_embedding(
+        self,
+        publication: PublicationModel,
+    ) -> PublicationEmbeddingModel | None:
+        for embedding in publication.embeddings:
+            if (
+                embedding.embedding_provider == self.settings.embeddings_provider
+                and embedding.embedding_model == self.settings.embeddings_model
+                and embedding.embedding_version == self.settings.embeddings_version
+                and embedding.qdrant_collection == self.settings.qdrant_collection_publications
+            ):
+                return embedding
+        return None
+
+    def _target_publication_id(
+        self,
+        *,
+        point_id: str,
+        payload: dict[str, Any],
+        point_id_to_publication_id: dict[str, str],
+    ) -> str | None:
+        publication_id = payload.get("publication_id")
+        if publication_id is not None:
+            return str(publication_id)
+        return point_id_to_publication_id.get(point_id)
+
+    def _publication_label(self, title: str) -> str:
+        compact = " ".join(title.split())
+        if len(compact) <= 120:
+            return compact
+        return f"{compact[:117]}..."
+
+    def _publication_year(self, publication: PublicationModel) -> int | None:
+        if publication.publication_year is not None:
+            return int(publication.publication_year)
+        if publication.publication_date is not None:
+            return int(publication.publication_date.year)
+        return None
+
+    def _publication_author_names(self, publication: PublicationModel) -> list[str]:
+        ordered_authors = sorted(publication.authors, key=lambda author: author.author_position)
+        author_names: list[str] = []
+        for author in ordered_authors:
+            if author.researcher is not None and author.researcher.full_name.strip():
+                author_names.append(author.researcher.full_name.strip())
+                continue
+            if author.author_list_name is not None and author.author_list_name.strip():
+                author_names.append(author.author_list_name.strip())
+        return author_names
+
+    def _publication_organization_ids(self, publication: PublicationModel) -> list[str]:
+        identifiers = {
+            str(link.organization.id)
+            for link in publication.organizations
+            if link.organization is not None
+        }
+        return sorted(identifiers)
+
+    def _publication_organization_names(self, publication: PublicationModel) -> list[str]:
+        names = {
+            link.organization.name
+            for link in publication.organizations
+            if link.organization is not None and link.organization.name
+        }
+        return sorted(names)
+
+    def _isoformat_or_none(self, value: datetime | None) -> str | None:
+        return value.isoformat() if value is not None else None

--- a/backend/src/eunigraph/modules/semantic_graph/infrastructure/__init__.py
+++ b/backend/src/eunigraph/modules/semantic_graph/infrastructure/__init__.py
@@ -1,0 +1,5 @@
+"""Semantic graph infrastructure adapters."""
+
+from eunigraph.modules.semantic_graph.infrastructure.models import SemanticGraphBuildModel
+
+__all__ = ["SemanticGraphBuildModel"]

--- a/backend/src/eunigraph/modules/semantic_graph/infrastructure/models.py
+++ b/backend/src/eunigraph/modules/semantic_graph/infrastructure/models.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import Boolean, DateTime, Index, Integer, String, Text, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from eunigraph.persistence.postgres.base import Base
+from eunigraph.persistence.postgres.mixins import TimestampMixin, UUIDPrimaryKeyMixin
+
+
+class SemanticGraphBuildModel(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "semantic_graph_build"
+    __table_args__ = (
+        Index("ix_semantic_graph_build_status", "status"),
+        Index("ix_semantic_graph_build_active", "graph_type", "is_active"),
+        Index("ix_semantic_graph_build_started_at", "started_at"),
+    )
+
+    graph_type: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        default="semantic_similarity",
+        server_default="semantic_similarity",
+    )
+    status: Mapped[str] = mapped_column(String(32), nullable=False)
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    triggered_by: Mapped[str | None] = mapped_column(String(100))
+    build_params: Mapped[dict[str, Any] | None] = mapped_column(JSONB)
+    data_snapshot: Mapped[dict[str, Any] | None] = mapped_column(JSONB)
+    artifact_paths: Mapped[dict[str, str] | None] = mapped_column(JSONB)
+    graph_version: Mapped[str | None] = mapped_column(String(64))
+    node_count: Mapped[int | None] = mapped_column(Integer)
+    edge_count: Mapped[int | None] = mapped_column(Integer)
+    component_count: Mapped[int | None] = mapped_column(Integer)
+    community_count: Mapped[int | None] = mapped_column(Integer)
+    is_active: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=False,
+        server_default="false",
+    )
+    error_message: Mapped[str | None] = mapped_column(Text)

--- a/backend/src/eunigraph/persistence/postgres/models.py
+++ b/backend/src/eunigraph/persistence/postgres/models.py
@@ -22,6 +22,7 @@ from eunigraph.modules.normalization.infrastructure.models import (
     NormalizationFindingModel,
     NormalizationRunModel,
 )
+from eunigraph.modules.semantic_graph.infrastructure.models import SemanticGraphBuildModel
 
 __all__ = [
     "CoauthorshipGraphBuildModel",
@@ -37,5 +38,6 @@ __all__ = [
     "PublicationOrganizationModel",
     "ResearcherAffiliationModel",
     "ResearcherModel",
+    "SemanticGraphBuildModel",
     "SourceRecordModel",
 ]

--- a/backend/tests/unit/test_metadata.py
+++ b/backend/tests/unit/test_metadata.py
@@ -20,6 +20,7 @@ def test_metadata_contains_initial_tables() -> None:
         "normalization_run",
         "normalization_finding",
         "coauthorship_graph_build",
+        "semantic_graph_build",
     }
 
     assert expected_tables.issubset(set(Base.metadata.tables))

--- a/backend/tests/unit/test_semantic_graph.py
+++ b/backend/tests/unit/test_semantic_graph.py
@@ -1,0 +1,449 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+from uuid import UUID, uuid4
+
+from sqlalchemy.orm import Session
+
+from eunigraph.modules.catalog.infrastructure.models import (
+    OrganizationModel,
+    PublicationAuthorModel,
+    PublicationModel,
+    PublicationOrganizationModel,
+    ResearcherModel,
+)
+from eunigraph.modules.embeddings.infrastructure.models import PublicationEmbeddingModel
+from eunigraph.modules.semantic_graph.application import SemanticGraphService
+from eunigraph.persistence.postgres import models  # noqa: F401
+
+
+class FakeSession:
+    def __init__(self, values: Sequence[object]) -> None:
+        self._values = values
+
+    def scalars(self, _query: object) -> list[object]:
+        return list(self._values)
+
+
+class FakeVectorStore:
+    def __init__(self, results_by_point_id: dict[str, list[dict[str, Any]]]) -> None:
+        self.results_by_point_id = results_by_point_id
+
+    def get_collection_status(self, _collection_name: str) -> dict[str, Any]:
+        return {"exists": True, "points_count": 3, "status": "green"}
+
+    def get_collection_distance(self, _collection_name: str) -> str:
+        return "Cosine"
+
+    def query_similar_publications(
+        self,
+        *,
+        collection_name: str,
+        point_id: str,
+        limit: int,
+        score_threshold: float | None,
+    ) -> list[dict[str, Any]]:
+        del collection_name
+        results = list(self.results_by_point_id.get(point_id, []))[:limit]
+        if score_threshold is None:
+            return results
+        return [result for result in results if result["score"] >= score_threshold]
+
+
+def _settings() -> Any:
+    return SimpleNamespace(
+        semantic_graph_storage_path=Path("/tmp/eunigraph-semantic-test-graphs"),
+        embeddings_provider="gemini",
+        embeddings_model="gemini-embedding-001",
+        embeddings_version="v1",
+        qdrant_collection_publications="publication_embeddings",
+    )
+
+
+def _publication(
+    *,
+    publication_id: UUID,
+    title: str,
+    point_id: str,
+    publication_year: int,
+    organization: OrganizationModel | None = None,
+    author_name: str | None = None,
+) -> PublicationModel:
+    publication = PublicationModel(
+        id=publication_id,
+        title=title,
+        normalized_title=title.lower(),
+        publication_year=publication_year,
+    )
+    publication.embeddings = [
+        PublicationEmbeddingModel(
+            id=uuid4(),
+            publication_id=publication_id,
+            embedding_provider="gemini",
+            qdrant_collection="publication_embeddings",
+            qdrant_point_id=point_id,
+            embedding_model="gemini-embedding-001",
+            embedding_version="v1",
+            content_hash=f"hash-{point_id}",
+        ),
+    ]
+    if organization is not None:
+        publication.organizations = [
+            PublicationOrganizationModel(
+                publication_id=publication_id,
+                organization_id=organization.id,
+                relation_type="affiliated_with",
+                organization=organization,
+            ),
+        ]
+    if author_name is not None:
+        researcher = ResearcherModel(
+            id=uuid4(),
+            full_name=author_name,
+            normalized_name=author_name.lower(),
+        )
+        publication.authors = [
+            PublicationAuthorModel(
+                publication_id=publication_id,
+                researcher_id=researcher.id,
+                author_position=1,
+                researcher=researcher,
+            ),
+        ]
+    return publication
+
+
+def test_collect_graph_inputs_builds_union_edges_and_mutual_flags() -> None:
+    org = OrganizationModel(id=uuid4(), name="Uni", normalized_name="uni")
+    pub_a = _publication(
+        publication_id=uuid4(),
+        title="Paper A",
+        point_id="point-a",
+        publication_year=2022,
+        organization=org,
+        author_name="Ada Lovelace",
+    )
+    pub_b = _publication(
+        publication_id=uuid4(),
+        title="Paper B",
+        point_id="point-b",
+        publication_year=2023,
+        organization=org,
+        author_name="Grace Hopper",
+    )
+    pub_c = _publication(
+        publication_id=uuid4(),
+        title="Paper C",
+        point_id="point-c",
+        publication_year=2024,
+        author_name="Alan Turing",
+    )
+    vector_store = FakeVectorStore(
+        {
+            "point-a": [
+                {
+                    "point_id": "point-a",
+                    "score": 1.0,
+                    "payload": {"publication_id": str(pub_a.id)},
+                },
+                {
+                    "point_id": "point-b",
+                    "score": 0.91,
+                    "payload": {"publication_id": str(pub_b.id)},
+                },
+            ],
+            "point-b": [
+                {
+                    "point_id": "point-a",
+                    "score": 0.88,
+                    "payload": {"publication_id": str(pub_a.id)},
+                },
+                {
+                    "point_id": "point-c",
+                    "score": 0.82,
+                    "payload": {"publication_id": str(pub_c.id)},
+                },
+            ],
+            "point-c": [
+                {
+                    "point_id": "point-b",
+                    "score": 0.79,
+                    "payload": {"publication_id": str(pub_b.id)},
+                },
+            ],
+        },
+    )
+    service = SemanticGraphService(
+        cast(Session, FakeSession([])),
+        _settings(),
+        vector_store=cast(Any, vector_store),
+    )
+
+    node_map, edge_map = service._collect_graph_inputs(
+        publications=[pub_a, pub_b, pub_c],
+        top_k=2,
+        score_threshold=0.75,
+        mutual_knn=False,
+        edge_symmetry_policy="max_score_union",
+        include_isolated_nodes=False,
+    )
+
+    ab_key = (
+        str(pub_a.id) if str(pub_a.id) < str(pub_b.id) else str(pub_b.id),
+        str(pub_b.id) if str(pub_a.id) < str(pub_b.id) else str(pub_a.id),
+    )
+    bc_key = (
+        str(pub_b.id) if str(pub_b.id) < str(pub_c.id) else str(pub_c.id),
+        str(pub_c.id) if str(pub_b.id) < str(pub_c.id) else str(pub_b.id),
+    )
+    assert set(node_map) == {str(pub_a.id), str(pub_b.id), str(pub_c.id)}
+    assert edge_map[ab_key]["weight"] == 0.91
+    assert edge_map[ab_key]["mutual_match"] is True
+    assert edge_map[bc_key]["weight"] == 0.82
+    assert edge_map[bc_key]["mutual_match"] is True
+    assert node_map[str(pub_a.id)]["authors"] == ["Ada Lovelace"]
+    assert node_map[str(pub_a.id)]["organization_names"] == ["Uni"]
+
+
+def test_collect_graph_inputs_respects_mutual_knn_and_drops_one_way_edges() -> None:
+    pub_a = _publication(
+        publication_id=uuid4(),
+        title="Paper A",
+        point_id="point-a",
+        publication_year=2022,
+    )
+    pub_b = _publication(
+        publication_id=uuid4(),
+        title="Paper B",
+        point_id="point-b",
+        publication_year=2023,
+    )
+    pub_c = _publication(
+        publication_id=uuid4(),
+        title="Paper C",
+        point_id="point-c",
+        publication_year=2024,
+    )
+    vector_store = FakeVectorStore(
+        {
+            "point-a": [
+                {"point_id": "point-b", "score": 0.9, "payload": {"publication_id": str(pub_b.id)}},
+            ],
+            "point-b": [],
+            "point-c": [],
+        },
+    )
+    service = SemanticGraphService(
+        cast(Session, FakeSession([])),
+        _settings(),
+        vector_store=cast(Any, vector_store),
+    )
+
+    node_map, edge_map = service._collect_graph_inputs(
+        publications=[pub_a, pub_b, pub_c],
+        top_k=2,
+        score_threshold=0.7,
+        mutual_knn=True,
+        edge_symmetry_policy="max_score_union",
+        include_isolated_nodes=False,
+    )
+
+    assert node_map == {}
+    assert edge_map == {}
+
+
+def test_filter_subgraph_by_publication_and_organization() -> None:
+    service = SemanticGraphService(cast(Session, FakeSession([])), _settings())
+    publication_id = str(uuid4())
+    related_id = str(uuid4())
+    external_id = str(uuid4())
+    org_id = str(uuid4())
+    payload = {
+        "build_id": str(uuid4()),
+        "graph_type": "semantic_similarity",
+        "generated_at": "2026-04-14T12:00:00+00:00",
+        "summary": {
+            "node_count": 3,
+            "edge_count": 2,
+            "component_count": 1,
+            "community_count": 1,
+            "graph_version": "abc123",
+        },
+        "data_snapshot": {},
+        "nodes": [
+            {
+                "id": publication_id,
+                "label": "Paper A",
+                "title": "Paper A",
+                "normalized_title": "paper a",
+                "publication_year": 2024,
+                "doi": None,
+                "openaire_id": None,
+                "publication_type": None,
+                "language_code": None,
+                "journal_name": None,
+                "venue_name": None,
+                "authors": [],
+                "organization_ids": [org_id],
+                "organization_names": ["Uni"],
+                "degree": 2,
+                "strength": 1.7,
+                "betweenness": 1.0,
+                "component_id": 0,
+                "community_id": 0,
+            },
+            {
+                "id": related_id,
+                "label": "Paper B",
+                "title": "Paper B",
+                "normalized_title": "paper b",
+                "publication_year": 2024,
+                "doi": None,
+                "openaire_id": None,
+                "publication_type": None,
+                "language_code": None,
+                "journal_name": None,
+                "venue_name": None,
+                "authors": [],
+                "organization_ids": [org_id],
+                "organization_names": ["Uni"],
+                "degree": 1,
+                "strength": 0.9,
+                "betweenness": 0.0,
+                "component_id": 0,
+                "community_id": 0,
+            },
+            {
+                "id": external_id,
+                "label": "Paper C",
+                "title": "Paper C",
+                "normalized_title": "paper c",
+                "publication_year": 2022,
+                "doi": None,
+                "openaire_id": None,
+                "publication_type": None,
+                "language_code": None,
+                "journal_name": None,
+                "venue_name": None,
+                "authors": [],
+                "organization_ids": [],
+                "organization_names": [],
+                "degree": 1,
+                "strength": 0.8,
+                "betweenness": 0.0,
+                "component_id": 0,
+                "community_id": 0,
+            },
+        ],
+        "edges": [
+            {
+                "source": publication_id,
+                "target": related_id,
+                "weight": 0.9,
+                "similarity_score": 0.9,
+                "rank": 1,
+                "mutual_match": True,
+                "source_rank": 1,
+                "target_rank": 1,
+                "source_score": 0.9,
+                "target_score": 0.88,
+            },
+            {
+                "source": publication_id,
+                "target": external_id,
+                "weight": 0.4,
+                "similarity_score": 0.4,
+                "rank": 2,
+                "mutual_match": False,
+                "source_rank": 2,
+                "target_rank": None,
+                "source_score": 0.4,
+                "target_score": None,
+            },
+        ],
+    }
+
+    subgraph = service._filter_subgraph(
+        payload,
+        publication_id=UUID(publication_id),
+        organization_id=UUID(org_id),
+        publication_year=2024,
+        max_nodes=2,
+        min_edge_weight=0.5,
+        community_id=None,
+    )
+
+    assert subgraph["summary"]["node_count"] == 2
+    assert subgraph["summary"]["edge_count"] == 1
+    assert {node["id"] for node in subgraph["nodes"]} == {publication_id, related_id}
+
+
+def test_render_svg_for_graph_uses_scatter_layout_without_labels() -> None:
+    service = SemanticGraphService(cast(Session, FakeSession([])), _settings())
+
+    svg = service._render_svg(
+        [
+            {
+                "id": "publication-a",
+                "label": "Paper A",
+                "title": "Paper A",
+                "normalized_title": "paper a",
+                "publication_year": 2024,
+                "doi": None,
+                "openaire_id": None,
+                "publication_type": None,
+                "language_code": None,
+                "journal_name": None,
+                "venue_name": None,
+                "authors": [],
+                "organization_ids": [],
+                "organization_names": [],
+                "degree": 2,
+                "strength": 1.5,
+                "betweenness": 0.4,
+                "component_id": 0,
+                "community_id": 0,
+            },
+            {
+                "id": "publication-b",
+                "label": "Paper B",
+                "title": "Paper B",
+                "normalized_title": "paper b",
+                "publication_year": 2024,
+                "doi": None,
+                "openaire_id": None,
+                "publication_type": None,
+                "language_code": None,
+                "journal_name": None,
+                "venue_name": None,
+                "authors": [],
+                "organization_ids": [],
+                "organization_names": [],
+                "degree": 1,
+                "strength": 0.8,
+                "betweenness": 0.0,
+                "component_id": 0,
+                "community_id": 0,
+            },
+        ],
+        [
+            {
+                "source": "publication-a",
+                "target": "publication-b",
+                "weight": 0.8,
+                "similarity_score": 0.8,
+                "rank": 1,
+                "mutual_match": True,
+                "source_rank": 1,
+                "target_rank": 1,
+                "source_score": 0.8,
+                "target_score": 0.79,
+            },
+        ],
+    )
+
+    assert "<text" not in svg
+    assert 'r="' in svg

--- a/docs/seed-and-api.md
+++ b/docs/seed-and-api.md
@@ -101,6 +101,15 @@ Coauthorship graph endpoints:
 - `GET /api/v1/coauthorship-graph/nodes/{researcher_id}`
 - `GET /api/v1/coauthorship-graph/visualization`
 
+Semantic graph endpoints:
+- `POST /api/v1/semantic-graph/build`
+- `GET /api/v1/semantic-graph/status`
+- `GET /api/v1/semantic-graph`
+- `GET /api/v1/semantic-graph/subgraph`
+- `GET /api/v1/semantic-graph/metrics`
+- `GET /api/v1/semantic-graph/nodes/{publication_id}`
+- `GET /api/v1/semantic-graph/visualization`
+
 Embeddings endpoints:
 - `GET /api/v1/embeddings/provider`
 - `GET /api/v1/embeddings/status`
@@ -188,6 +197,38 @@ Default artifact path:
 - default value: `data/graphs/coauthorship/`
 
 Retrieval endpoints always use the latest successful active build. A failed rebuild does not force the API to reconstruct the graph live.
+
+## Semantic Graph Materialization
+
+The semantic graph is materialized from publication embeddings already stored in Qdrant and then served from persisted artifacts.
+
+Current characteristics:
+- nodes derive from canonical `publication`
+- edges derive from Qdrant nearest neighbors
+- graph type is undirected
+- weights use the Qdrant similarity score
+- self-loops are discarded
+- duplicate edges are collapsed into one undirected relation
+
+Artifacts persisted for each build:
+- a `graph-tool` binary graph file
+- a JSON payload used by retrieval APIs
+- a static SVG visualization
+- build metadata in `semantic_graph_build`
+
+Default storage path:
+- `data/graphs/semantic/`
+
+Build parameters exposed by the API include:
+- `top_k`
+- `score_threshold`
+- `edge_symmetry_policy`
+- `mutual_knn`
+- `include_isolated_nodes`
+- optional `publication_type`
+- optional `language_code`
+- optional `year_from`
+- optional `year_to`
 
 ## Embeddings Layer
 

--- a/docs/semantic-graph.md
+++ b/docs/semantic-graph.md
@@ -1,0 +1,140 @@
+# Semantic Similarity Graph Pipeline
+
+## Purpose
+
+This document describes how EuniGraph builds, persists and serves the semantic similarity graph.
+
+The goal is to transform publication embeddings already stored in Qdrant into a materialized publication-publication graph that can be reused by APIs and future frontend visualizations without rebuilding on every request.
+
+## Data Sources
+
+The semantic graph is built from:
+- Qdrant as the source of vector nearest neighbors
+- PostgreSQL as the canonical source of publication metadata
+- `publication_embedding` as the explicit bridge between canonical publications and Qdrant points
+
+Nodes are canonical `publication` entities.
+
+Edges are derived from nearest-neighbor retrieval over the Qdrant publication collection.
+
+## Build Strategy
+
+The MVP uses:
+- an undirected graph
+- no self-loops
+- no duplicate edges
+- `top_k + score_threshold` pruning
+- score-based edge weights
+- optional `mutual_knn`
+
+The default behavior is:
+- `top_k = 5`
+- `score_threshold = 0.75`
+- `edge_symmetry_policy = max_score_union`
+- `mutual_knn = false`
+
+### Edge Construction
+
+For each publication with an active embedding:
+1. query nearest neighbors from Qdrant
+2. discard self-matches
+3. keep up to `top_k` valid neighbors after filtering
+4. drop neighbors below the configured threshold
+5. convert directional nearest-neighbor links into one undirected edge per publication pair
+
+Current edge fields include:
+- `source`
+- `target`
+- `weight`
+- `similarity_score`
+- `rank`
+- `mutual_match`
+- `source_rank`
+- `target_rank`
+- `source_score`
+- `target_score`
+
+With `edge_symmetry_policy = max_score_union`, one-sided matches are allowed and the undirected edge keeps the best score observed across directions.
+
+With `mutual_knn = true` or `edge_symmetry_policy = mutual_only`, only reciprocal nearest-neighbor matches are kept.
+
+## Build Parameters
+
+The build API exposes these parameters:
+- `top_k`
+- `score_threshold`
+- `edge_symmetry_policy`
+- `mutual_knn`
+- `include_isolated_nodes`
+- optional `publication_type`
+- optional `language_code`
+- optional `year_from`
+- optional `year_to`
+
+The resolved build metadata also records:
+- Qdrant collection
+- Qdrant distance metric
+- embedding provider
+- embedding model
+- embedding version
+- weight strategy
+
+## Materialization and Storage
+
+The semantic graph is materialized exactly once per build and stored on disk.
+
+Default storage path:
+- `data/graphs/semantic/`
+
+Each build writes:
+- `semantic_graph.gt`
+- `semantic_graph.json`
+- `semantic_graph.svg`
+
+The backend Docker setup already mounts `data/graphs/` as persistent writable storage.
+
+## Build Tracking
+
+Each build is tracked in PostgreSQL through `semantic_graph_build`.
+
+Tracked metadata includes:
+- build status
+- start and completion timestamps
+- resolved build parameters
+- source snapshot
+- artifact paths
+- node and edge counts
+- component and community counts
+- graph version hash
+- last error if the build failed
+
+Only the latest successful active build is used by retrieval endpoints.
+
+## Retrieval Model
+
+Retrieval APIs never rebuild the graph live.
+
+They read the persisted JSON artifact of the latest successful build and expose:
+- the full graph
+- filtered subgraphs
+- graph-level metrics
+- node-level metrics
+- a static SVG visualization
+
+## Available Endpoints
+
+- `POST /api/v1/semantic-graph/build`
+- `GET /api/v1/semantic-graph/status`
+- `GET /api/v1/semantic-graph`
+- `GET /api/v1/semantic-graph/subgraph`
+- `GET /api/v1/semantic-graph/metrics`
+- `GET /api/v1/semantic-graph/nodes/{publication_id}`
+- `GET /api/v1/semantic-graph/visualization`
+
+## Current Limitations
+
+- no automatic rebuild after embedding refreshes
+- no query-time semantic search endpoint yet
+- no cross-modal similarity graph
+- score semantics depend on the Qdrant collection distance currently configured
+- organization filters operate on already materialized publication-organization links, not on a dedicated semantic index


### PR DESCRIPTION
- Introduced `SemanticGraphBuildModel` to represent the semantic graph build in the database.
- Created infrastructure module for semantic graph with necessary imports and model definitions.
- Updated persistence layer to include the new semantic graph model.
- Added tests for semantic graph functionality, ensuring correct behavior of graph input collection and filtering.
- Documented new semantic graph API endpoints and build process in the relevant markdown files.