### PR TITLE
Add OpenAIRE seed tests and enhance error handling in ingestion process

### DIFF
--- a/backend/src/eunigraph/api/openapi.py
+++ b/backend/src/eunigraph/api/openapi.py
@@ -53,6 +53,10 @@ COMMON_ERROR_RESPONSES = {
         "model": ApiErrorResponse,
         "description": "The request is syntactically valid but violates application rules.",
     },
+    409: {
+        "model": ApiErrorResponse,
+        "description": "The request conflicts with the current application or persistence state.",
+    },
     404: {
         "model": ApiErrorResponse,
         "description": "The requested resource or materialized artifact was not found.",

--- a/backend/src/eunigraph/api/routers/admin.py
+++ b/backend/src/eunigraph/api/routers/admin.py
@@ -52,7 +52,11 @@ def get_seed_status(
         "Run the local OpenAIRE Beginner's Kit seed workflow using "
         "the configured dataset path."
     ),
-    responses={400: COMMON_ERROR_RESPONSES[400]},
+    responses={
+        400: COMMON_ERROR_RESPONSES[400],
+        409: COMMON_ERROR_RESPONSES[409],
+        503: COMMON_ERROR_RESPONSES[503],
+    },
 )
 def load_seed(
     payload: OpenAireSeedLoadRequest,

--- a/backend/src/eunigraph/api/schemas/admin.py
+++ b/backend/src/eunigraph/api/schemas/admin.py
@@ -30,6 +30,7 @@ class OpenAireSeedLoadResponse(BaseModel):
 class OpenAireSeedResetResponse(BaseModel):
     publication_author: int
     publication_organization: int
+    researcher_affiliation: int
     external_identifier: int
     publication: int
     researcher: int

--- a/backend/src/eunigraph/modules/ingestion/application/openaire_beginners_kit.py
+++ b/backend/src/eunigraph/modules/ingestion/application/openaire_beginners_kit.py
@@ -3,16 +3,19 @@ from __future__ import annotations
 import gzip
 import hashlib
 import json
+import logging
 import tarfile
 from collections.abc import Iterator
 from dataclasses import dataclass
-from datetime import date
+from datetime import UTC, date, datetime
+from json import JSONDecodeError
 from pathlib import Path
 from typing import Any
 from uuid import UUID
 
 from fastapi import HTTPException, status
 from sqlalchemy import delete, func, select
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from eunigraph.core.config import Settings
@@ -22,6 +25,7 @@ from eunigraph.modules.catalog.infrastructure.models import (
     PublicationAuthorModel,
     PublicationModel,
     PublicationOrganizationModel,
+    ResearcherAffiliationModel,
     ResearcherModel,
 )
 from eunigraph.modules.ingestion.infrastructure.models import (
@@ -38,6 +42,8 @@ REQUIRED_ARCHIVES = (
     "project.tar",
     "relation.tar",
 )
+PROGRESS_LOG_INTERVAL = 100
+logger = logging.getLogger(__name__)
 
 
 @dataclass(slots=True)
@@ -50,10 +56,56 @@ class SeedStatus:
     latest_ingestion_status: str | None
 
 
+@dataclass(slots=True)
+class SeedLoadError(Exception):
+    category: str
+    stage: str
+    message: str
+    status_code: int
+    archive_name: str | None = None
+    processed_records: int | None = None
+    limit_per_file: int | None = None
+
+    def detail(self) -> str:
+        parts = [f"Seed {self.category} error during {self.stage}: {self.message}"]
+        if self.archive_name:
+            parts.append(f"archive={self.archive_name}")
+        if self.processed_records is not None:
+            parts.append(f"processed_records={self.processed_records}")
+        if self.limit_per_file is not None:
+            parts.append(f"limit_per_file={self.limit_per_file}")
+        return " | ".join(parts)
+
+    def to_http_exception(self) -> HTTPException:
+        return HTTPException(
+            status_code=self.status_code,
+            detail=self.detail(),
+        )
+
+
 class OpenAireBeginnersKitSeeder:
     def __init__(self, session: Session, settings: Settings) -> None:
         self.session = session
         self.settings = settings
+        self._source_record_cache: dict[tuple[UUID, str, str], SourceRecordModel] = {}
+        self._external_identifier_cache: dict[tuple[str, str, str], UUID] = {}
+        self._organization_by_openaire_id: dict[str, OrganizationModel] = {}
+        self._organization_by_ror_id: dict[str, OrganizationModel] = {}
+        self._organization_by_normalized_name: dict[str, OrganizationModel] = {}
+        self._researcher_by_orcid: dict[str, ResearcherModel] = {}
+        self._researcher_by_normalized_name: dict[str, ResearcherModel] = {}
+        self._publication_by_openaire_id: dict[str, PublicationModel] = {}
+        self._publication_by_doi: dict[str, PublicationModel] = {}
+        self._publication_by_title_year: dict[tuple[str, int | None], PublicationModel] = {}
+        self._publication_author_researchers: dict[UUID, set[UUID]] = {}
+        self._publication_author_positions: dict[UUID, set[int]] = {}
+        self._publication_organization_relations: set[tuple[UUID, UUID, str]] = set()
+        self._researcher_affiliation_pairs: set[tuple[UUID, UUID]] = set()
+        self._researcher_affiliations_by_researcher: dict[
+            UUID,
+            list[ResearcherAffiliationModel],
+        ] = {}
+        self._researcher_affiliation_orgs: dict[UUID, set[UUID]] = {}
 
     def get_status(self) -> SeedStatus:
         dataset_path = Path(self.settings.openaire_beginners_kit_path)
@@ -74,6 +126,7 @@ class OpenAireBeginnersKitSeeder:
             "publication": self._count(PublicationModel),
             "publication_author": self._count(PublicationAuthorModel),
             "publication_organization": self._count(PublicationOrganizationModel),
+            "researcher_affiliation": self._count(ResearcherAffiliationModel),
             "external_identifier": self._count(ExternalIdentifierModel),
         }
 
@@ -92,6 +145,11 @@ class OpenAireBeginnersKitSeeder:
     def load(self, *, limit_per_file: int | None = None) -> dict[str, int | str | None]:
         dataset_path = self._validate_dataset_path()
         data_source = self._get_or_create_logical_source()
+        logger.info(
+            "OpenAIRE seed started dataset_path=%s limit_per_file=%s",
+            dataset_path,
+            limit_per_file,
+        )
 
         ingestion_run = IngestionRunModel(
             data_source_id=data_source.id,
@@ -101,6 +159,12 @@ class OpenAireBeginnersKitSeeder:
         )
         self.session.add(ingestion_run)
         self.session.flush()
+        self.session.commit()
+        logger.info(
+            "OpenAIRE seed ingestion run created ingestion_run_id=%s data_source_id=%s",
+            ingestion_run.id,
+            data_source.id,
+        )
 
         counts = {
             "datasource_records": 0,
@@ -142,15 +206,74 @@ class OpenAireBeginnersKitSeeder:
                 limit_per_file,
             )
             ingestion_run.status = "completed"
+            ingestion_run.completed_at = datetime.now(UTC)
             self.session.commit()
+            logger.info(
+                "OpenAIRE seed completed ingestion_run_id=%s datasource_records=%s "
+                "organization_records=%s publication_records=%s project_records=%s "
+                "relation_records=%s",
+                ingestion_run.id,
+                counts["datasource_records"],
+                counts["organization_records"],
+                counts["publication_records"],
+                counts["project_records"],
+                counts["relation_records"],
+            )
+        except SeedLoadError as exc:
+            self.session.rollback()
+            logger.warning(
+                "OpenAIRE seed failed ingestion_run_id=%s detail=%s",
+                ingestion_run.id,
+                exc.detail(),
+                exc_info=True,
+            )
+            self._mark_ingestion_run_failed(ingestion_run.id, exc.detail())
+            raise exc.to_http_exception() from exc
+        except MemoryError as exc:
+            self.session.rollback()
+            seed_error = SeedLoadError(
+                category="resources",
+                stage="seed execution",
+                message="The seed loader exhausted available memory while processing the dataset",
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                limit_per_file=limit_per_file,
+            )
+            logger.exception(
+                "OpenAIRE seed resource failure ingestion_run_id=%s",
+                ingestion_run.id,
+            )
+            self._mark_ingestion_run_failed(ingestion_run.id, seed_error.detail())
+            raise seed_error.to_http_exception() from exc
+        except SQLAlchemyError as exc:
+            self.session.rollback()
+            seed_error = SeedLoadError(
+                category="db",
+                stage="seed persistence",
+                message=self._format_db_error(exc),
+                status_code=status.HTTP_409_CONFLICT,
+                limit_per_file=limit_per_file,
+            )
+            logger.exception(
+                "OpenAIRE seed database failure ingestion_run_id=%s",
+                ingestion_run.id,
+            )
+            self._mark_ingestion_run_failed(ingestion_run.id, seed_error.detail())
+            raise seed_error.to_http_exception() from exc
         except Exception as exc:  # pragma: no cover - defensive rollback path
             self.session.rollback()
-            failed_run = self.session.get(IngestionRunModel, ingestion_run.id)
-            if failed_run is not None:
-                failed_run.status = "failed"
-                failed_run.notes = str(exc)
-                self.session.commit()
-            raise
+            seed_error = SeedLoadError(
+                category="integration",
+                stage="seed execution",
+                message=str(exc) or exc.__class__.__name__,
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                limit_per_file=limit_per_file,
+            )
+            logger.exception(
+                "OpenAIRE seed unexpected failure ingestion_run_id=%s",
+                ingestion_run.id,
+            )
+            self._mark_ingestion_run_failed(ingestion_run.id, seed_error.detail())
+            raise seed_error.to_http_exception() from exc
 
         return {
             "dataset_path": str(dataset_path),
@@ -163,6 +286,7 @@ class OpenAireBeginnersKitSeeder:
         deleted_counts = {
             "publication_author": self._count(PublicationAuthorModel),
             "publication_organization": self._count(PublicationOrganizationModel),
+            "researcher_affiliation": self._count(ResearcherAffiliationModel),
             "external_identifier": self._count(ExternalIdentifierModel),
             "publication": self._count(PublicationModel),
             "researcher": self._count(ResearcherModel),
@@ -173,6 +297,7 @@ class OpenAireBeginnersKitSeeder:
         }
         self.session.execute(delete(PublicationAuthorModel))
         self.session.execute(delete(PublicationOrganizationModel))
+        self.session.execute(delete(ResearcherAffiliationModel))
         self.session.execute(delete(ExternalIdentifierModel))
         self.session.execute(delete(PublicationModel))
         self.session.execute(delete(ResearcherModel))
@@ -232,24 +357,61 @@ class OpenAireBeginnersKitSeeder:
         limit: int | None,
     ) -> Iterator[dict[str, Any]]:
         yielded = 0
-        with tarfile.open(archive_path, mode="r") as archive:
-            for member in archive:
-                if not member.isfile() or not member.name.endswith(".gz"):
-                    continue
+        try:
+            with tarfile.open(archive_path, mode="r") as archive:
+                for member in archive:
+                    if not member.isfile() or not member.name.endswith(".gz"):
+                        continue
 
-                extracted = archive.extractfile(member)
-                if extracted is None:
-                    continue
+                    extracted = archive.extractfile(member)
+                    if extracted is None:
+                        continue
 
-                with gzip.open(extracted, mode="rt", encoding="utf-8") as handle:
-                    for line in handle:
-                        if limit is not None and yielded >= limit:
-                            return
-                        stripped = line.strip()
-                        if not stripped:
-                            continue
-                        yielded += 1
-                        yield json.loads(stripped)
+                    try:
+                        with gzip.open(extracted, mode="rt", encoding="utf-8") as handle:
+                            for line_number, line in enumerate(handle, start=1):
+                                if limit is not None and yielded >= limit:
+                                    return
+                                stripped = line.strip()
+                                if not stripped:
+                                    continue
+                                try:
+                                    payload = json.loads(stripped)
+                                except JSONDecodeError as exc:
+                                    raise SeedLoadError(
+                                        category="parsing",
+                                        stage="json parsing",
+                                        message=(
+                                            f"Invalid JSON record in {member.name} at line "
+                                            f"{line_number}: {exc.msg}"
+                                        ),
+                                        status_code=status.HTTP_400_BAD_REQUEST,
+                                        archive_name=archive_path.name,
+                                        processed_records=yielded,
+                                        limit_per_file=limit,
+                                    ) from exc
+                                yielded += 1
+                                yield payload
+                    except (OSError, UnicodeDecodeError) as exc:
+                        raise SeedLoadError(
+                            category="parsing",
+                            stage="archive decompression",
+                            message=f"Unable to read archive member {member.name}: {exc}",
+                            status_code=status.HTTP_400_BAD_REQUEST,
+                            archive_name=archive_path.name,
+                            processed_records=yielded,
+                            limit_per_file=limit,
+                        ) from exc
+        except tarfile.TarError as exc:
+            raise SeedLoadError(
+                category="parsing",
+                stage="archive parsing",
+                message=f"Unable to open archive {archive_path.name}: {exc}",
+                status_code=status.HTTP_400_BAD_REQUEST,
+                archive_name=archive_path.name,
+                processed_records=yielded,
+                limit_per_file=limit,
+            ) from exc
 
     def _create_source_record(
         self,
@@ -261,6 +423,27 @@ class OpenAireBeginnersKitSeeder:
         payload: dict[str, Any],
     ) -> SourceRecordModel:
         checksum = hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
+        cache_key = (ingestion_run_id, entity_type, source_identifier)
+        cached_record = self._source_record_cache.get(cache_key)
+        if cached_record is not None:
+            if cached_record.checksum != checksum:
+                logger.warning(
+                    "OpenAIRE seed encountered duplicate source record with changed payload "
+                    "ingestion_run_id=%s entity_type=%s source_identifier=%s",
+                    ingestion_run_id,
+                    entity_type,
+                    source_identifier,
+                )
+            else:
+                logger.info(
+                    "OpenAIRE seed skipped duplicate source record "
+                    "ingestion_run_id=%s entity_type=%s source_identifier=%s",
+                    ingestion_run_id,
+                    entity_type,
+                    source_identifier,
+                )
+            return cached_record
+
         record = SourceRecordModel(
             data_source_id=data_source_id,
             ingestion_run_id=ingestion_run_id,
@@ -271,6 +454,7 @@ class OpenAireBeginnersKitSeeder:
         )
         self.session.add(record)
         self.session.flush()
+        self._source_record_cache[cache_key] = record
         return record
 
     def _process_datasources(
@@ -281,16 +465,30 @@ class OpenAireBeginnersKitSeeder:
         limit: int | None,
     ) -> int:
         processed = 0
-        for payload in self._iter_archive_records(archive_path, limit=limit):
-            source_identifier = self._payload_identifier(payload)
-            self._create_source_record(
-                data_source_id=data_source_id,
-                ingestion_run_id=ingestion_run_id,
-                entity_type="datasource",
-                source_identifier=source_identifier,
-                payload=payload,
-            )
-            processed += 1
+        self._log_archive_start("datasource", archive_path, limit, ingestion_run_id)
+        try:
+            for payload in self._iter_archive_records(archive_path, limit=limit):
+                source_identifier = self._payload_identifier(payload)
+                self._create_source_record(
+                    data_source_id=data_source_id,
+                    ingestion_run_id=ingestion_run_id,
+                    entity_type="datasource",
+                    source_identifier=source_identifier,
+                    payload=payload,
+                )
+                processed += 1
+                self._log_archive_progress("datasource", archive_path, processed, limit)
+        except SeedLoadError:
+            raise
+        except SQLAlchemyError as exc:
+            raise self._build_seed_db_error(
+                stage="datasource persistence",
+                archive_path=archive_path,
+                processed_records=processed,
+                limit=limit,
+                exc=exc,
+            ) from exc
+        self._log_archive_complete("datasource", archive_path, processed, limit)
         return processed
 
     def _process_projects(
@@ -301,16 +499,30 @@ class OpenAireBeginnersKitSeeder:
         limit: int | None,
     ) -> int:
         processed = 0
-        for payload in self._iter_archive_records(archive_path, limit=limit):
-            source_identifier = self._payload_identifier(payload)
-            self._create_source_record(
-                data_source_id=data_source_id,
-                ingestion_run_id=ingestion_run_id,
-                entity_type="project",
-                source_identifier=source_identifier,
-                payload=payload,
-            )
-            processed += 1
+        self._log_archive_start("project", archive_path, limit, ingestion_run_id)
+        try:
+            for payload in self._iter_archive_records(archive_path, limit=limit):
+                source_identifier = self._payload_identifier(payload)
+                self._create_source_record(
+                    data_source_id=data_source_id,
+                    ingestion_run_id=ingestion_run_id,
+                    entity_type="project",
+                    source_identifier=source_identifier,
+                    payload=payload,
+                )
+                processed += 1
+                self._log_archive_progress("project", archive_path, processed, limit)
+        except SeedLoadError:
+            raise
+        except SQLAlchemyError as exc:
+            raise self._build_seed_db_error(
+                stage="project persistence",
+                archive_path=archive_path,
+                processed_records=processed,
+                limit=limit,
+                exc=exc,
+            ) from exc
+        self._log_archive_complete("project", archive_path, processed, limit)
         return processed
 
     def _process_organizations(
@@ -321,18 +533,32 @@ class OpenAireBeginnersKitSeeder:
         limit: int | None,
     ) -> int:
         processed = 0
-        for payload in self._iter_archive_records(archive_path, limit=limit):
-            source_identifier = self._payload_identifier(payload)
-            self._create_source_record(
-                data_source_id=data_source_id,
-                ingestion_run_id=ingestion_run_id,
-                entity_type="organization",
-                source_identifier=source_identifier,
-                payload=payload,
-            )
-            self._upsert_organization(payload)
-            processed += 1
-        self.session.flush()
+        self._log_archive_start("organization", archive_path, limit, ingestion_run_id)
+        try:
+            for payload in self._iter_archive_records(archive_path, limit=limit):
+                source_identifier = self._payload_identifier(payload)
+                self._create_source_record(
+                    data_source_id=data_source_id,
+                    ingestion_run_id=ingestion_run_id,
+                    entity_type="organization",
+                    source_identifier=source_identifier,
+                    payload=payload,
+                )
+                self._upsert_organization(payload)
+                processed += 1
+                self._log_archive_progress("organization", archive_path, processed, limit)
+            self.session.flush()
+        except SeedLoadError:
+            raise
+        except SQLAlchemyError as exc:
+            raise self._build_seed_db_error(
+                stage="organization persistence",
+                archive_path=archive_path,
+                processed_records=processed,
+                limit=limit,
+                exc=exc,
+            ) from exc
+        self._log_archive_complete("organization", archive_path, processed, limit)
         return processed
 
     def _process_publications(
@@ -343,20 +569,34 @@ class OpenAireBeginnersKitSeeder:
         limit: int | None,
     ) -> int:
         processed = 0
-        for payload in self._iter_archive_records(archive_path, limit=limit):
-            source_identifier = self._payload_identifier(payload)
-            source_record = self._create_source_record(
-                data_source_id=data_source_id,
-                ingestion_run_id=ingestion_run_id,
-                entity_type="publication",
-                source_identifier=source_identifier,
-                payload=payload,
-            )
-            publication = self._upsert_publication(payload, source_record.id)
-            self._upsert_publication_authors(publication, payload, source_record.id)
-            self._upsert_publication_identifiers(publication, payload, source_record.id)
-            processed += 1
-        self.session.flush()
+        self._log_archive_start("publication", archive_path, limit, ingestion_run_id)
+        try:
+            for payload in self._iter_archive_records(archive_path, limit=limit):
+                source_identifier = self._payload_identifier(payload)
+                source_record = self._create_source_record(
+                    data_source_id=data_source_id,
+                    ingestion_run_id=ingestion_run_id,
+                    entity_type="publication",
+                    source_identifier=source_identifier,
+                    payload=payload,
+                )
+                publication = self._upsert_publication(payload, source_record.id)
+                self._upsert_publication_authors(publication, payload, source_record.id)
+                self._upsert_publication_identifiers(publication, payload, source_record.id)
+                processed += 1
+                self._log_archive_progress("publication", archive_path, processed, limit)
+            self.session.flush()
+        except SeedLoadError:
+            raise
+        except SQLAlchemyError as exc:
+            raise self._build_seed_db_error(
+                stage="publication persistence",
+                archive_path=archive_path,
+                processed_records=processed,
+                limit=limit,
+                exc=exc,
+            ) from exc
+        self._log_archive_complete("publication", archive_path, processed, limit)
         return processed
 
     def _process_relations(
@@ -367,18 +607,33 @@ class OpenAireBeginnersKitSeeder:
         limit: int | None,
     ) -> int:
         processed = 0
-        for payload in self._iter_archive_records(archive_path, limit=limit):
-            source_identifier = self._payload_identifier(payload)
-            source_record = self._create_source_record(
-                data_source_id=data_source_id,
-                ingestion_run_id=ingestion_run_id,
-                entity_type="relation",
-                source_identifier=source_identifier,
-                payload=payload,
-            )
-            self._map_publication_organization_relation(payload, source_record.id)
-            processed += 1
-        self.session.flush()
+        self._log_archive_start("relation", archive_path, limit, ingestion_run_id)
+        try:
+            for payload in self._iter_archive_records(archive_path, limit=limit):
+                source_identifier = self._payload_identifier(payload)
+                source_record = self._create_source_record(
+                    data_source_id=data_source_id,
+                    ingestion_run_id=ingestion_run_id,
+                    entity_type="relation",
+                    source_identifier=source_identifier,
+                    payload=payload,
+                )
+                self._map_publication_organization_relation(payload, source_record.id)
+                self._map_researcher_affiliation_relation(payload, source_record.id)
+                processed += 1
+                self._log_archive_progress("relation", archive_path, processed, limit)
+            self.session.flush()
+        except SeedLoadError:
+            raise
+        except SQLAlchemyError as exc:
+            raise self._build_seed_db_error(
+                stage="relation persistence",
+                archive_path=archive_path,
+                processed_records=processed,
+                limit=limit,
+                exc=exc,
+            ) from exc
+        self._log_archive_complete("relation", archive_path, processed, limit)
         return processed
 
     def _upsert_organization(self, payload: dict[str, Any]) -> OrganizationModel:
@@ -395,19 +650,31 @@ class OpenAireBeginnersKitSeeder:
 
         organization = None
         if openaire_id:
-            organization = self.session.scalar(
-                select(OrganizationModel).where(OrganizationModel.openaire_id == openaire_id)
-            )
+            organization = self._organization_by_openaire_id.get(openaire_id)
+            if organization is None:
+                organization = self.session.scalar(
+                    select(OrganizationModel).where(OrganizationModel.openaire_id == openaire_id)
+                )
+                if organization is not None:
+                    self._register_organization_cache(organization)
         if organization is None and ror_id:
-            organization = self.session.scalar(
-                select(OrganizationModel).where(OrganizationModel.ror_id == ror_id),
-            )
+            organization = self._organization_by_ror_id.get(ror_id)
+            if organization is None:
+                organization = self.session.scalar(
+                    select(OrganizationModel).where(OrganizationModel.ror_id == ror_id),
+                )
+                if organization is not None:
+                    self._register_organization_cache(organization)
         if organization is None and normalized_name:
-            organization = self.session.scalar(
-                select(OrganizationModel).where(
-                    OrganizationModel.normalized_name == normalized_name,
-                ),
-            )
+            organization = self._organization_by_normalized_name.get(normalized_name)
+            if organization is None:
+                organization = self.session.scalar(
+                    select(OrganizationModel).where(
+                        OrganizationModel.normalized_name == normalized_name,
+                    ),
+                )
+                if organization is not None:
+                    self._register_organization_cache(organization)
 
         if organization is None:
             initial_name = (
@@ -420,8 +687,18 @@ class OpenAireBeginnersKitSeeder:
                 or openaire_id
             )
             organization = OrganizationModel(
-                name=initial_name,
-                normalized_name=normalized_name,
+                name=self._clip_text(
+                    initial_name,
+                    max_length=255,
+                    field_name="organization.name",
+                )
+                or initial_name,
+                normalized_name=self._clip_text(
+                    normalized_name,
+                    max_length=255,
+                    field_name="organization.normalized_name",
+                )
+                or normalized_name,
             )
             self.session.add(organization)
 
@@ -431,19 +708,62 @@ class OpenAireBeginnersKitSeeder:
             payload.get("officialname"),
             organization.name,
         )
-        organization.name = resolved_name or organization.name
-        organization.normalized_name = normalize_text(organization.name)
+        organization.name = (
+            self._clip_text(
+                resolved_name,
+                max_length=255,
+                field_name="organization.name",
+            )
+            or organization.name
+        )
+        organization.normalized_name = (
+            self._clip_text(
+                normalize_text(organization.name),
+                max_length=255,
+                field_name="organization.normalized_name",
+            )
+            or organization.normalized_name
+        )
         organization.organization_type = (
-            self._extract_value(payload.get("type")) or organization.organization_type
+            self._clip_text(
+                self._extract_value(payload.get("type")),
+                max_length=64,
+                field_name="organization.organization_type",
+            )
+            or organization.organization_type
         )
         organization.country_code = self._extract_country_code(payload) or organization.country_code
-        organization.city = payload.get("city") or organization.city
+        organization.city = (
+            self._clip_text(
+                self._coalesce(payload.get("city")),
+                max_length=120,
+                field_name="organization.city",
+            )
+            or organization.city
+        )
         organization.website = (
             self._extract_first(payload.get("websiteurl")) or organization.website
         )
-        organization.ror_id = ror_id or organization.ror_id
-        organization.openaire_id = openaire_id or organization.openaire_id
+        organization.ror_id = self._assign_unique_entity_value(
+            model=organization,
+            value=ror_id,
+            current_value=organization.ror_id,
+            field_name="organization.ror_id",
+            cache=self._organization_by_ror_id,
+            model_class=OrganizationModel,
+            model_field="ror_id",
+        )
+        organization.openaire_id = self._assign_unique_entity_value(
+            model=organization,
+            value=openaire_id,
+            current_value=organization.openaire_id,
+            field_name="organization.openaire_id",
+            cache=self._organization_by_openaire_id,
+            model_class=OrganizationModel,
+            model_field="openaire_id",
+        )
         self.session.flush()
+        self._register_organization_cache(organization)
         return organization
 
     def _upsert_publication(
@@ -463,23 +783,36 @@ class OpenAireBeginnersKitSeeder:
         normalized_title = normalize_text(title)
         doi = self._extract_pid_value(payload.get("pid"), "doi")
         openaire_id = self._payload_identifier(payload)
+        publication_year = self._extract_publication_year(payload)
 
         publication = None
         if openaire_id:
-            publication = self.session.scalar(
-                select(PublicationModel).where(PublicationModel.openaire_id == openaire_id)
-            )
-        if publication is None and doi:
-            publication = self.session.scalar(
-                select(PublicationModel).where(PublicationModel.doi == doi),
-            )
-        if publication is None:
-            publication = self.session.scalar(
-                select(PublicationModel).where(
-                    PublicationModel.normalized_title == normalized_title,
-                    PublicationModel.publication_year == self._extract_publication_year(payload),
+            publication = self._publication_by_openaire_id.get(openaire_id)
+            if publication is None:
+                publication = self.session.scalar(
+                    select(PublicationModel).where(PublicationModel.openaire_id == openaire_id)
                 )
-            )
+                if publication is not None:
+                    self._register_publication_cache(publication)
+        if publication is None and doi:
+            publication = self._publication_by_doi.get(doi)
+            if publication is None:
+                publication = self.session.scalar(
+                    select(PublicationModel).where(PublicationModel.doi == doi),
+                )
+                if publication is not None:
+                    self._register_publication_cache(publication)
+        if publication is None:
+            publication = self._publication_by_title_year.get((normalized_title, publication_year))
+            if publication is None:
+                publication = self.session.scalar(
+                    select(PublicationModel).where(
+                        PublicationModel.normalized_title == normalized_title,
+                        PublicationModel.publication_year == publication_year,
+                    )
+                )
+                if publication is not None:
+                    self._register_publication_cache(publication)
 
         if publication is None:
             publication = PublicationModel(title=title, normalized_title=normalized_title)
@@ -493,22 +826,60 @@ class OpenAireBeginnersKitSeeder:
         publication.publication_date = self._parse_date(
             self._coalesce(payload.get("publicationdate")),
         )
-        publication.publication_year = self._extract_publication_year(payload)
-        publication.doi = doi or publication.doi
-        publication.openaire_id = openaire_id or publication.openaire_id
+        publication.publication_year = publication_year
+        publication.doi = self._assign_unique_entity_value(
+            model=publication,
+            value=doi,
+            current_value=publication.doi,
+            field_name="publication.doi",
+            cache=self._publication_by_doi,
+            model_class=PublicationModel,
+            model_field="doi",
+        )
+        publication.openaire_id = self._assign_unique_entity_value(
+            model=publication,
+            value=openaire_id,
+            current_value=publication.openaire_id,
+            field_name="publication.openaire_id",
+            cache=self._publication_by_openaire_id,
+            model_class=PublicationModel,
+            model_field="openaire_id",
+        )
         publication.publication_type = (
-            self._extract_value(payload.get("type")) or publication.publication_type
+            self._clip_text(
+                self._extract_value(payload.get("type")),
+                max_length=64,
+                field_name="publication.publication_type",
+            )
+            or publication.publication_type
         )
-        publication.language_code = (
-            self._extract_value(payload.get("language")) or publication.language_code
-        )
+        publication.language_code = self._extract_language_code(
+            payload.get("language"),
+        ) or publication.language_code
         publication.journal_name = (
-            self._extract_container_name(payload) or publication.journal_name
+            self._clip_text(
+                self._extract_container_name(payload),
+                max_length=255,
+                field_name="publication.journal_name",
+            )
+            or publication.journal_name
         )
         publication.venue_name = (
-            self._extract_first(payload.get("source")) or publication.venue_name
+            self._clip_text(
+                self._extract_first(payload.get("source")),
+                max_length=255,
+                field_name="publication.venue_name",
+            )
+            or publication.venue_name
         )
-        publication.publisher = payload.get("publisher") or publication.publisher
+        publication.publisher = (
+            self._clip_text(
+                self._coalesce(payload.get("publisher")),
+                max_length=255,
+                field_name="publication.publisher",
+            )
+            or publication.publisher
+        )
         publication.open_access = self._extract_open_access(payload)
         publication.source_url = (
             self._extract_first_from_instances(payload, "url")
@@ -516,6 +887,7 @@ class OpenAireBeginnersKitSeeder:
         )
         publication.canonical_source_record_id = source_record_id
         self.session.flush()
+        self._register_publication_cache(publication)
         return publication
 
     def _upsert_publication_authors(
@@ -524,55 +896,167 @@ class OpenAireBeginnersKitSeeder:
         payload: dict[str, Any],
         source_record_id: UUID,
     ) -> None:
+        seen_researcher_ids = set(
+            self._publication_author_researchers.get(publication.id, set()),
+        )
+        used_positions = set(self._publication_author_positions.get(publication.id, set()))
+        if not seen_researcher_ids and not used_positions:
+            existing_relations = list(
+                self.session.scalars(
+                    select(PublicationAuthorModel).where(
+                        PublicationAuthorModel.publication_id == publication.id,
+                    )
+                )
+            )
+            seen_researcher_ids = {relation.researcher_id for relation in existing_relations}
+            used_positions = {relation.author_position for relation in existing_relations}
+            self._publication_author_researchers[publication.id] = set(seen_researcher_ids)
+            self._publication_author_positions[publication.id] = set(used_positions)
+
         for author_payload in payload.get("author") or []:
-            full_name = self._coalesce(
+            raw_full_name = self._coalesce(
                 author_payload.get("fullname"),
                 author_payload.get("fullName"),
             )
-            if not full_name:
+            if not raw_full_name:
                 continue
+            full_name = (
+                self._clip_text(
+                    raw_full_name,
+                    max_length=255,
+                    field_name="researcher.full_name",
+                )
+                or raw_full_name
+            )
 
             orcid = self._extract_nested_pid_value(author_payload.get("pid"), "orcid")
             researcher = None
             if orcid:
-                researcher = self.session.scalar(
-                    select(ResearcherModel).where(ResearcherModel.orcid == orcid),
-                )
+                researcher = self._researcher_by_orcid.get(orcid)
+                if researcher is None:
+                    researcher = self.session.scalar(
+                        select(ResearcherModel).where(ResearcherModel.orcid == orcid),
+                    )
+                    if researcher is not None:
+                        self._register_researcher_cache(researcher)
             if researcher is None:
-                normalized_author_name = normalize_text(full_name)
-                researcher = self.session.scalar(
-                    select(ResearcherModel).where(
-                        ResearcherModel.normalized_name == normalized_author_name,
-                    ),
+                normalized_author_name = (
+                    self._clip_text(
+                        normalize_text(raw_full_name),
+                        max_length=255,
+                        field_name="researcher.normalized_name",
+                    )
+                    or normalize_text(raw_full_name)
                 )
+                researcher = self._researcher_by_normalized_name.get(normalized_author_name)
+                if researcher is None:
+                    researcher = self.session.scalar(
+                        select(ResearcherModel).where(
+                            ResearcherModel.normalized_name == normalized_author_name,
+                        ),
+                    )
+                    if researcher is not None:
+                        self._register_researcher_cache(researcher)
 
             if researcher is None:
                 researcher = ResearcherModel(
                     full_name=full_name,
-                    given_name=author_payload.get("name"),
-                    family_name=author_payload.get("surname"),
-                    normalized_name=normalize_text(full_name),
-                    display_name=full_name,
-                    orcid=orcid,
+                    given_name=self._clip_text(
+                        self._coalesce(author_payload.get("name")),
+                        max_length=120,
+                        field_name="researcher.given_name",
+                    ),
+                    family_name=self._clip_text(
+                        self._coalesce(author_payload.get("surname")),
+                        max_length=120,
+                        field_name="researcher.family_name",
+                    ),
+                    normalized_name=(
+                        self._clip_text(
+                            normalize_text(raw_full_name),
+                            max_length=255,
+                            field_name="researcher.normalized_name",
+                        )
+                        or normalize_text(raw_full_name)
+                    ),
+                    display_name=self._clip_text(
+                        raw_full_name,
+                        max_length=255,
+                        field_name="researcher.display_name",
+                    )
+                    or full_name,
+                    orcid=None,
+                )
+                researcher.orcid = self._assign_unique_entity_value(
+                    model=researcher,
+                    value=orcid,
+                    current_value=researcher.orcid,
+                    field_name="researcher.orcid",
+                    cache=self._researcher_by_orcid,
+                    model_class=ResearcherModel,
+                    model_field="orcid",
                 )
                 self.session.add(researcher)
                 self.session.flush()
+                self._register_researcher_cache(researcher)
+            else:
+                researcher.orcid = self._assign_unique_entity_value(
+                    model=researcher,
+                    value=orcid,
+                    current_value=researcher.orcid,
+                    field_name="researcher.orcid",
+                    cache=self._researcher_by_orcid,
+                    model_class=ResearcherModel,
+                    model_field="orcid",
+                )
+                self._register_researcher_cache(researcher)
 
-            relation = self.session.scalar(
-                select(PublicationAuthorModel).where(
-                    PublicationAuthorModel.publication_id == publication.id,
-                    PublicationAuthorModel.researcher_id == researcher.id,
+            if researcher.id in seen_researcher_ids:
+                logger.info(
+                    "OpenAIRE seed skipped duplicate publication_author relation "
+                    "publication_id=%s researcher_id=%s source_record_id=%s author_name=%s",
+                    publication.id,
+                    researcher.id,
+                    source_record_id,
+                    full_name,
                 )
+                continue
+
+            preferred_position = self._parse_author_position(author_payload.get("rank"))
+            author_position = self._next_available_author_position(
+                preferred_position,
+                used_positions,
             )
-            if relation is None:
-                relation = PublicationAuthorModel(
-                    publication_id=publication.id,
-                    researcher_id=researcher.id,
-                    author_position=int(author_payload.get("rank") or 0),
-                    author_list_name=full_name,
-                    source_record_id=source_record_id,
+            if preferred_position != author_position:
+                logger.info(
+                    "OpenAIRE seed normalized author position publication_id=%s "
+                    "researcher_id=%s preferred_position=%s assigned_position=%s",
+                    publication.id,
+                    researcher.id,
+                    preferred_position,
+                    author_position,
                 )
-                self.session.add(relation)
+
+            relation = PublicationAuthorModel(
+                publication_id=publication.id,
+                researcher_id=researcher.id,
+                author_position=author_position,
+                author_list_name=self._clip_text(
+                    raw_full_name,
+                    max_length=255,
+                    field_name="publication_author.author_list_name",
+                )
+                or full_name,
+                source_record_id=source_record_id,
+            )
+            self.session.add(relation)
+            seen_researcher_ids.add(researcher.id)
+            self._publication_author_researchers.setdefault(publication.id, set()).add(
+                researcher.id
+            )
+            self._publication_author_positions.setdefault(publication.id, set()).add(
+                author_position
+            )
 
     def _upsert_publication_identifiers(
         self,
@@ -581,18 +1065,64 @@ class OpenAireBeginnersKitSeeder:
         source_record_id: UUID,
     ) -> None:
         identifiers: list[tuple[str, str]] = []
+        seen_identifiers: set[tuple[str, str]] = set()
 
         for pid in payload.get("pid") or []:
             identifier_type = (pid.get("scheme") or "").lower().strip()
             identifier_value = (pid.get("value") or "").strip()
             if identifier_type and identifier_value:
-                identifiers.append((identifier_type, identifier_value))
+                identifier_key = (identifier_type, identifier_value)
+                if identifier_key in seen_identifiers:
+                    logger.info(
+                        "OpenAIRE seed skipped duplicate publication identifier in payload "
+                        "publication_id=%s identifier_type=%s identifier_value=%s",
+                        publication.id,
+                        identifier_type,
+                        identifier_value,
+                    )
+                    continue
+                seen_identifiers.add(identifier_key)
+                identifiers.append(identifier_key)
 
         for original_id in payload.get("originalId") or []:
             if isinstance(original_id, str) and original_id.strip():
-                identifiers.append(("original_id", original_id.strip()))
+                identifier_key = ("original_id", original_id.strip())
+                if identifier_key in seen_identifiers:
+                    logger.info(
+                        "OpenAIRE seed skipped duplicate publication identifier in payload "
+                        "publication_id=%s identifier_type=%s identifier_value=%s",
+                        publication.id,
+                        identifier_key[0],
+                        identifier_key[1],
+                    )
+                    continue
+                seen_identifiers.add(identifier_key)
+                identifiers.append(identifier_key)
 
         for identifier_type, identifier_value in identifiers:
+            cache_key = ("publication", identifier_type, identifier_value)
+            cached_entity_id = self._external_identifier_cache.get(cache_key)
+            if cached_entity_id is not None:
+                if cached_entity_id == publication.id:
+                    logger.info(
+                        "OpenAIRE seed skipped duplicate cached external identifier "
+                        "publication_id=%s identifier_type=%s identifier_value=%s",
+                        publication.id,
+                        identifier_type,
+                        identifier_value,
+                    )
+                else:
+                    logger.warning(
+                        "OpenAIRE seed skipped conflicting external identifier "
+                        "publication_id=%s existing_publication_id=%s identifier_type=%s "
+                        "identifier_value=%s",
+                        publication.id,
+                        cached_entity_id,
+                        identifier_type,
+                        identifier_value,
+                    )
+                continue
+
             existing = self.session.scalar(
                 select(ExternalIdentifierModel).where(
                     ExternalIdentifierModel.entity_type == "publication",
@@ -600,55 +1130,50 @@ class OpenAireBeginnersKitSeeder:
                     ExternalIdentifierModel.identifier_value == identifier_value,
                 )
             )
-            if existing is None:
-                self.session.add(
-                    ExternalIdentifierModel(
-                        entity_type="publication",
-                        entity_id=publication.id,
-                        identifier_type=identifier_type,
-                        identifier_value=identifier_value,
-                        is_primary=identifier_type == "doi" and identifier_value == publication.doi,
-                        source_record_id=source_record_id,
+            if existing is not None:
+                self._external_identifier_cache[cache_key] = existing.entity_id
+                if existing.entity_id != publication.id:
+                    logger.warning(
+                        "OpenAIRE seed skipped pre-existing external identifier conflict "
+                        "publication_id=%s existing_publication_id=%s identifier_type=%s "
+                        "identifier_value=%s",
+                        publication.id,
+                        existing.entity_id,
+                        identifier_type,
+                        identifier_value,
                     )
-                )
+                continue
 
+            self.session.add(
+                ExternalIdentifierModel(
+                    entity_type="publication",
+                    entity_id=publication.id,
+                    identifier_type=identifier_type,
+                    identifier_value=identifier_value,
+                    is_primary=identifier_type == "doi" and identifier_value == publication.doi,
+                    source_record_id=source_record_id,
+                )
+            )
+            self._external_identifier_cache[cache_key] = publication.id
     def _map_publication_organization_relation(
         self,
         payload: dict[str, Any],
         source_record_id: UUID,
     ) -> None:
-        source_id = payload.get("source")
-        target_id = payload.get("target")
-        if not isinstance(source_id, str) or not isinstance(target_id, str):
+        resolved = self._resolve_publication_organization_relation(payload)
+        if resolved is None:
             return
 
-        relation_type = self._extract_relation_type(payload)
-        source_type = self._extract_relation_side_type(payload.get("sourceType"))
-        target_type = self._extract_relation_side_type(payload.get("targetType"))
-
-        organization_identifier: str | None = None
-        publication_identifier: str | None = None
-
-        if self._is_organization_type(source_type) and self._is_publication_type(target_type):
-            organization_identifier = source_id
-            publication_identifier = target_id
-        elif self._is_publication_type(source_type) and self._is_organization_type(target_type):
-            publication_identifier = source_id
-            organization_identifier = target_id
-        else:
-            return
-
-        organization = self.session.scalar(
-            select(OrganizationModel).where(
-                OrganizationModel.openaire_id == organization_identifier,
+        publication, organization, relation_type = resolved
+        cache_key = (publication.id, organization.id, relation_type)
+        if cache_key in self._publication_organization_relations:
+            logger.info(
+                "OpenAIRE seed skipped duplicate publication_organization relation "
+                "publication_id=%s organization_id=%s relation_type=%s",
+                publication.id,
+                organization.id,
+                relation_type,
             )
-        )
-        publication = self.session.scalar(
-            select(PublicationModel).where(
-                PublicationModel.openaire_id == publication_identifier,
-            )
-        )
-        if organization is None or publication is None:
             return
 
         existing = self.session.scalar(
@@ -667,6 +1192,166 @@ class OpenAireBeginnersKitSeeder:
                     source_record_id=source_record_id,
                 )
             )
+        self._publication_organization_relations.add(cache_key)
+
+    def _map_researcher_affiliation_relation(
+        self,
+        payload: dict[str, Any],
+        source_record_id: UUID,
+    ) -> None:
+        if not self._is_affiliation_relation(payload):
+            return
+
+        resolved = self._resolve_publication_organization_relation(payload)
+        if resolved is None:
+            return
+
+        publication, organization, _relation_type = resolved
+        authors = list(
+            self.session.scalars(
+                select(PublicationAuthorModel).where(
+                    PublicationAuthorModel.publication_id == publication.id,
+                )
+            )
+        )
+        if len(authors) != 1:
+            return
+
+        self._upsert_researcher_affiliation(
+            researcher_id=authors[0].researcher_id,
+            organization_id=organization.id,
+            source_record_id=source_record_id,
+        )
+
+    def _upsert_researcher_affiliation(
+        self,
+        *,
+        researcher_id: UUID,
+        organization_id: UUID,
+        source_record_id: UUID,
+    ) -> None:
+        cache_key = (researcher_id, organization_id)
+        if cache_key in self._researcher_affiliation_pairs:
+            return
+
+        existing_affiliations = self._researcher_affiliations_by_researcher.get(researcher_id)
+        if existing_affiliations is None:
+            existing_affiliations = list(
+                self.session.scalars(
+                    select(ResearcherAffiliationModel).where(
+                        ResearcherAffiliationModel.researcher_id == researcher_id,
+                    )
+                )
+            )
+            self._researcher_affiliations_by_researcher[researcher_id] = existing_affiliations
+            self._researcher_affiliation_orgs[researcher_id] = {
+                affiliation.organization_id for affiliation in existing_affiliations
+            }
+            self._researcher_affiliation_pairs.update(
+                (affiliation.researcher_id, affiliation.organization_id)
+                for affiliation in existing_affiliations
+            )
+            if cache_key in self._researcher_affiliation_pairs:
+                return
+
+        affiliation = ResearcherAffiliationModel(
+            researcher_id=researcher_id,
+            organization_id=organization_id,
+            is_primary=False,
+            source_record_id=source_record_id,
+        )
+        self.session.add(affiliation)
+        self.session.flush()
+
+        self._researcher_affiliations_by_researcher.setdefault(
+            researcher_id,
+            [],
+        ).append(affiliation)
+        self._researcher_affiliation_orgs.setdefault(researcher_id, set()).add(organization_id)
+        self._researcher_affiliation_pairs.add(cache_key)
+        self._refresh_researcher_primary_organization(researcher_id)
+
+    def _refresh_researcher_primary_organization(self, researcher_id: UUID) -> None:
+        researcher = self.session.get(ResearcherModel, researcher_id)
+        if researcher is None:
+            return
+
+        affiliations = self._researcher_affiliations_by_researcher.get(researcher_id)
+        if affiliations is None:
+            affiliations = list(
+                self.session.scalars(
+                    select(ResearcherAffiliationModel).where(
+                        ResearcherAffiliationModel.researcher_id == researcher_id,
+                    )
+                )
+            )
+            self._researcher_affiliations_by_researcher[researcher_id] = affiliations
+            self._researcher_affiliation_orgs[researcher_id] = {
+                affiliation.organization_id for affiliation in affiliations
+            }
+
+        organization_ids = self._researcher_affiliation_orgs.get(researcher_id, set())
+        if len(organization_ids) == 1:
+            primary_organization_id = next(iter(organization_ids))
+            researcher.primary_organization_id = primary_organization_id
+            for affiliation in affiliations:
+                affiliation.is_primary = affiliation.organization_id == primary_organization_id
+        else:
+            researcher.primary_organization_id = None
+            for affiliation in affiliations:
+                affiliation.is_primary = False
+
+        self._register_researcher_cache(researcher)
+
+    def _resolve_publication_organization_relation(
+        self,
+        payload: dict[str, Any],
+    ) -> tuple[PublicationModel, OrganizationModel, str] | None:
+        source_id = payload.get("source")
+        target_id = payload.get("target")
+        if not isinstance(source_id, str) or not isinstance(target_id, str):
+            return None
+
+        relation_type = self._extract_relation_type(payload)
+        source_type = self._extract_relation_side_type(payload.get("sourceType"))
+        target_type = self._extract_relation_side_type(payload.get("targetType"))
+
+        organization_identifier: str | None = None
+        publication_identifier: str | None = None
+
+        if self._is_organization_type(source_type) and self._is_publication_type(target_type):
+            organization_identifier = source_id
+            publication_identifier = target_id
+        elif self._is_publication_type(source_type) and self._is_organization_type(target_type):
+            publication_identifier = source_id
+            organization_identifier = target_id
+        else:
+            return None
+
+        organization = self._organization_by_openaire_id.get(organization_identifier)
+        if organization is None:
+            organization = self.session.scalar(
+                select(OrganizationModel).where(
+                    OrganizationModel.openaire_id == organization_identifier,
+                )
+            )
+            if organization is not None:
+                self._register_organization_cache(organization)
+
+        publication = self._publication_by_openaire_id.get(publication_identifier)
+        if publication is None:
+            publication = self.session.scalar(
+                select(PublicationModel).where(
+                    PublicationModel.openaire_id == publication_identifier,
+                )
+            )
+            if publication is not None:
+                self._register_publication_cache(publication)
+
+        if organization is None or publication is None:
+            return None
+
+        return publication, organization, relation_type
 
     def _payload_identifier(self, payload: dict[str, Any]) -> str:
         identifier = payload.get("id")
@@ -739,6 +1424,96 @@ class OpenAireBeginnersKitSeeder:
             return value.strip()
         return None
 
+    def _clip_text(
+        self,
+        value: str | None,
+        *,
+        max_length: int,
+        field_name: str,
+    ) -> str | None:
+        if value is None:
+            return None
+        if len(value) <= max_length:
+            return value
+        logger.info(
+            "OpenAIRE seed truncated overlong field field=%s original_length=%s max_length=%s",
+            field_name,
+            len(value),
+            max_length,
+        )
+        return value[:max_length].rstrip()
+
+    def _same_entity(self, left: Any, right: Any) -> bool:
+        if left is right:
+            return True
+        left_id = getattr(left, "id", None)
+        right_id = getattr(right, "id", None)
+        if left_id is None or right_id is None:
+            return False
+        return bool(left_id == right_id)
+
+    def _assign_unique_entity_value(
+        self,
+        *,
+        model: Any,
+        value: str | None,
+        current_value: str | None,
+        field_name: str,
+        cache: dict[str, Any],
+        model_class: type[Any],
+        model_field: str,
+    ) -> str | None:
+        if not value:
+            return current_value
+        if current_value == value:
+            cache[value] = model
+            return current_value
+
+        cached_model = cache.get(value)
+        if cached_model is None:
+            cached_model = self.session.scalar(
+                select(model_class).where(getattr(model_class, model_field) == value),
+            )
+            if cached_model is not None:
+                cache[value] = cached_model
+
+        if cached_model is not None and not self._same_entity(cached_model, model):
+            logger.warning(
+                "OpenAIRE seed skipped conflicting unique field field=%s value=%s "
+                "entity_id=%s existing_entity_id=%s",
+                field_name,
+                value,
+                model.id,
+                cached_model.id,
+            )
+            return current_value
+
+        cache[value] = model
+        return value
+
+    def _register_organization_cache(self, organization: OrganizationModel) -> None:
+        if organization.openaire_id:
+            self._organization_by_openaire_id[organization.openaire_id] = organization
+        if organization.ror_id:
+            self._organization_by_ror_id[organization.ror_id] = organization
+        if organization.normalized_name:
+            self._organization_by_normalized_name[organization.normalized_name] = organization
+
+    def _register_researcher_cache(self, researcher: ResearcherModel) -> None:
+        if researcher.orcid:
+            self._researcher_by_orcid[researcher.orcid] = researcher
+        if researcher.normalized_name:
+            self._researcher_by_normalized_name[researcher.normalized_name] = researcher
+
+    def _register_publication_cache(self, publication: PublicationModel) -> None:
+        if publication.openaire_id:
+            self._publication_by_openaire_id[publication.openaire_id] = publication
+        if publication.doi:
+            self._publication_by_doi[publication.doi] = publication
+        self._publication_by_title_year[
+            (publication.normalized_title, publication.publication_year)
+        ] = publication
+
     def _extract_value(self, value: Any) -> str | None:
         if isinstance(value, dict):
             for key in ("value", "label", "code", "name"):
@@ -748,6 +1523,34 @@ class OpenAireBeginnersKitSeeder:
             return None
         if isinstance(value, str) and value.strip():
             return value.strip()
+        return None
+
+    def _extract_language_code(self, value: Any) -> str | None:
+        if isinstance(value, dict):
+            for key in ("code", "iso", "isoCode", "value"):
+                candidate = value.get(key)
+                if isinstance(candidate, str) and candidate.strip():
+                    return candidate.strip()[:16]
+            for key in ("label", "name"):
+                candidate = value.get(key)
+                if isinstance(candidate, str) and candidate.strip():
+                    stripped = candidate.strip()
+                    if len(stripped) <= 16:
+                        return stripped
+                    logger.info(
+                        "OpenAIRE seed skipped overlong language label value=%s",
+                        stripped,
+                    )
+                    return None
+            return None
+        if isinstance(value, str) and value.strip():
+            stripped = value.strip()
+            if len(stripped) <= 16:
+                return stripped
+            logger.info(
+                "OpenAIRE seed skipped overlong language value value=%s",
+                stripped,
+            )
         return None
 
     def _extract_container_name(self, payload: dict[str, Any]) -> str | None:
@@ -798,6 +1601,20 @@ class OpenAireBeginnersKitSeeder:
             return reltype.strip()
         return "unknown"
 
+    def _is_affiliation_relation(self, payload: dict[str, Any]) -> bool:
+        reltype = payload.get("reltype")
+        if isinstance(reltype, dict):
+            relation_category = reltype.get("type")
+            if (
+                isinstance(relation_category, str)
+                and relation_category.strip().casefold() == "affiliation"
+            ):
+                return True
+        return self._extract_relation_type(payload).casefold() in {
+            "hasauthorinstitution",
+            "isauthorinstitutionof",
+        }
+
     def _extract_relation_side_type(self, value: Any) -> str:
         if isinstance(value, dict):
             for key in ("name", "value", "code", "label"):
@@ -819,3 +1636,125 @@ class OpenAireBeginnersKitSeeder:
             if isinstance(value, str) and value.strip():
                 return value.strip()
         return None
+
+    def _parse_author_position(self, value: Any) -> int | None:
+        if value is None:
+            return None
+        if isinstance(value, str) and not value.strip():
+            return None
+        try:
+            position = int(value)
+        except (TypeError, ValueError):
+            return None
+        if position < 1:
+            return None
+        return position
+
+    def _next_available_author_position(
+        self,
+        preferred_position: int | None,
+        used_positions: set[int],
+    ) -> int:
+        if preferred_position is not None and preferred_position not in used_positions:
+            used_positions.add(preferred_position)
+            return preferred_position
+
+        candidate = 1
+        while candidate in used_positions:
+            candidate += 1
+        used_positions.add(candidate)
+        return candidate
+
+    def _log_archive_start(
+        self,
+        entity_type: str,
+        archive_path: Path,
+        limit: int | None,
+        ingestion_run_id: UUID,
+    ) -> None:
+        logger.info(
+            "OpenAIRE seed phase started entity_type=%s archive=%s ingestion_run_id=%s "
+            "limit_per_file=%s",
+            entity_type,
+            archive_path.name,
+            ingestion_run_id,
+            limit,
+        )
+
+    def _log_archive_progress(
+        self,
+        entity_type: str,
+        archive_path: Path,
+        processed: int,
+        limit: int | None,
+    ) -> None:
+        if processed % PROGRESS_LOG_INTERVAL != 0:
+            return
+        logger.info(
+            "OpenAIRE seed phase progress entity_type=%s archive=%s processed_records=%s "
+            "limit_per_file=%s",
+            entity_type,
+            archive_path.name,
+            processed,
+            limit,
+        )
+
+    def _log_archive_complete(
+        self,
+        entity_type: str,
+        archive_path: Path,
+        processed: int,
+        limit: int | None,
+    ) -> None:
+        logger.info(
+            "OpenAIRE seed phase completed entity_type=%s archive=%s processed_records=%s "
+            "limit_per_file=%s",
+            entity_type,
+            archive_path.name,
+            processed,
+            limit,
+        )
+
+    def _format_db_error(self, exc: SQLAlchemyError) -> str:
+        original = getattr(exc, "orig", None)
+        return str(original or exc)
+
+    def _build_seed_db_error(
+        self,
+        *,
+        stage: str,
+        archive_path: Path,
+        processed_records: int,
+        limit: int | None,
+        exc: SQLAlchemyError,
+    ) -> SeedLoadError:
+        return SeedLoadError(
+            category="db",
+            stage=stage,
+            message=self._format_db_error(exc),
+            status_code=status.HTTP_409_CONFLICT,
+            archive_name=archive_path.name,
+            processed_records=processed_records,
+            limit_per_file=limit,
+        )
+
+    def _mark_ingestion_run_failed(self, ingestion_run_id: UUID, notes: str) -> None:
+        failed_run = self.session.get(IngestionRunModel, ingestion_run_id)
+        if failed_run is None:
+            logger.error(
+                "OpenAIRE seed failed to persist ingestion status ingestion_run_id=%s",
+                ingestion_run_id,
+            )
+            return
+
+        failed_run.status = "failed"
+        failed_run.completed_at = datetime.now(UTC)
+        failed_run.notes = notes
+        try:
+            self.session.commit()
+        except SQLAlchemyError:
+            self.session.rollback()
+            logger.exception(
+                "OpenAIRE seed failed to store failure metadata ingestion_run_id=%s",
+                ingestion_run_id,
+            )

--- a/backend/src/eunigraph/modules/ingestion/application/seed_cli.py
+++ b/backend/src/eunigraph/modules/ingestion/application/seed_cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 from collections.abc import Mapping
+from dataclasses import asdict
 
 from eunigraph.core.config import get_settings
 from eunigraph.modules.ingestion.application.openaire_beginners_kit import (
@@ -28,7 +29,7 @@ def main() -> None:
         elif args.command == "reset":
             result = seeder.reset()
         else:
-            result = seeder.get_status().__dict__
+            result = asdict(seeder.get_status())
         print(json.dumps(result, default=str, indent=2))
     finally:
         session.close()

--- a/backend/tests/unit/test_openaire_seed.py
+++ b/backend/tests/unit/test_openaire_seed.py
@@ -1,0 +1,384 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+from uuid import UUID, uuid4
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from eunigraph.modules.catalog.infrastructure.models import (
+    ExternalIdentifierModel,
+    OrganizationModel,
+    PublicationAuthorModel,
+    PublicationModel,
+    PublicationOrganizationModel,
+    ResearcherAffiliationModel,
+    ResearcherModel,
+)
+from eunigraph.modules.ingestion.application.openaire_beginners_kit import (
+    OpenAireBeginnersKitSeeder,
+    SeedLoadError,
+)
+from eunigraph.modules.ingestion.infrastructure.models import (
+    DataSourceModel,
+    IngestionRunModel,
+)
+from eunigraph.persistence.postgres import models  # noqa: F401
+
+
+class FakeSeedSession:
+    def __init__(
+        self,
+        *,
+        scalar_values: list[object | None] | None = None,
+        existing_relations: list[PublicationAuthorModel] | None = None,
+        scalars_values: list[list[object]] | None = None,
+        get_values: dict[UUID, object] | None = None,
+    ) -> None:
+        self.scalar_values = list(scalar_values or [])
+        self.existing_relations = list(existing_relations or [])
+        self.scalars_values = list(scalars_values or [])
+        self.added: list[object] = []
+        self.commit_calls = 0
+        self.rollback_calls = 0
+        self.flush_calls = 0
+        self.ingestion_runs: dict[UUID, IngestionRunModel] = {}
+        self.get_values = dict(get_values or {})
+
+    def add(self, value: object) -> None:
+        self.added.append(value)
+
+    def flush(self) -> None:
+        self.flush_calls += 1
+        for value in self.added:
+            object_id = getattr(value, "id", None)
+            if object_id is None:
+                cast(Any, value).id = uuid4()
+            if isinstance(value, IngestionRunModel):
+                self.ingestion_runs[value.id] = value
+
+    def commit(self) -> None:
+        self.commit_calls += 1
+        self.flush()
+
+    def rollback(self) -> None:
+        self.rollback_calls += 1
+
+    def scalar(self, _query: object) -> object | None:
+        if not self.scalar_values:
+            return None
+        return self.scalar_values.pop(0)
+
+    def scalars(self, _query: object) -> list[object]:
+        if self.scalars_values:
+            return list(self.scalars_values.pop(0))
+        return list(self.existing_relations)
+
+    def get(self, _model: type[object], key: UUID) -> IngestionRunModel | None:
+        if key in self.get_values:
+            return cast(IngestionRunModel | None, self.get_values[key])
+        return self.ingestion_runs.get(key)
+
+
+class FailingSeeder(OpenAireBeginnersKitSeeder):
+    def _validate_dataset_path(self) -> Path:
+        return Path("/tmp/openaire-beginners-kit")
+
+    def _get_or_create_logical_source(self) -> DataSourceModel:
+        return DataSourceModel(
+            id=uuid4(),
+            name="OpenAIRE Beginner's Kit",
+            source_type="openaire_beginners_kit",
+        )
+
+    def _process_datasources(
+        self,
+        archive_path: Path,
+        data_source_id: UUID,
+        ingestion_run_id: UUID,
+        limit: int | None,
+    ) -> int:
+        raise SeedLoadError(
+            category="db",
+            stage="publication persistence",
+            message="duplicate key value violates unique constraint uq_publication_author_pair",
+            status_code=status.HTTP_409_CONFLICT,
+            archive_name="publication.tar",
+            processed_records=151,
+            limit_per_file=limit,
+        )
+
+
+def _settings() -> object:
+    return SimpleNamespace(openaire_beginners_kit_path="data/openaire/beginners_kit")
+
+
+def test_upsert_publication_authors_skips_duplicate_researcher_links_and_reassigns_rank() -> None:
+    publication = PublicationModel(id=uuid4(), title="Test", normalized_title="test")
+    ada = ResearcherModel(
+        id=uuid4(),
+        full_name="Ada Lovelace",
+        normalized_name="ada lovelace",
+    )
+    grace = ResearcherModel(
+        id=uuid4(),
+        full_name="Grace Hopper",
+        normalized_name="grace hopper",
+    )
+    session = FakeSeedSession(scalar_values=[ada, grace])
+    seeder = OpenAireBeginnersKitSeeder(cast(Session, session), cast(Any, _settings()))
+
+    seeder._upsert_publication_authors(
+        publication,
+        {
+            "author": [
+                {"fullname": "Ada Lovelace", "rank": "1"},
+                {"fullname": "Ada Lovelace", "rank": "1"},
+                {"fullname": "Grace Hopper", "rank": "1"},
+            ]
+        },
+        uuid4(),
+    )
+
+    relations = [
+        item for item in session.added if isinstance(item, PublicationAuthorModel)
+    ]
+
+    assert len(relations) == 2
+    assert {relation.researcher_id for relation in relations} == {ada.id, grace.id}
+    assert sorted(relation.author_position for relation in relations) == [1, 2]
+
+
+def test_extract_language_code_prefers_short_code_over_long_label() -> None:
+    session = FakeSeedSession()
+    seeder = OpenAireBeginnersKitSeeder(cast(Session, session), cast(Any, _settings()))
+
+    extracted = seeder._extract_language_code({"code": "eng", "label": "English"})
+
+    assert extracted == "eng"
+    assert (
+        seeder._extract_language_code(
+            {"label": "Greek, Modern (1453-)"}
+        )
+        is None
+    )
+
+
+def test_clip_text_truncates_overlong_descriptive_fields() -> None:
+    session = FakeSeedSession()
+    seeder = OpenAireBeginnersKitSeeder(cast(Session, session), cast(Any, _settings()))
+
+    clipped = seeder._clip_text("x" * 130, max_length=120, field_name="researcher.given_name")
+
+    assert clipped == "x" * 120
+
+
+def test_create_source_record_reuses_duplicate_identifier_within_same_run() -> None:
+    session = FakeSeedSession()
+    seeder = OpenAireBeginnersKitSeeder(cast(Session, session), cast(Any, _settings()))
+    ingestion_run_id = uuid4()
+    data_source_id = uuid4()
+
+    first = seeder._create_source_record(
+        data_source_id=data_source_id,
+        ingestion_run_id=ingestion_run_id,
+        entity_type="datasource",
+        source_identifier="re3data_____::duplicate",
+        payload={"id": "re3data_____::duplicate", "name": "first"},
+    )
+    second = seeder._create_source_record(
+        data_source_id=data_source_id,
+        ingestion_run_id=ingestion_run_id,
+        entity_type="datasource",
+        source_identifier="re3data_____::duplicate",
+        payload={"id": "re3data_____::duplicate", "name": "first"},
+    )
+
+    assert first is second
+    assert len([item for item in session.added if item is first]) == 1
+
+
+def test_upsert_publication_identifiers_skips_conflicting_duplicates_within_same_run() -> None:
+    session = FakeSeedSession()
+    seeder = OpenAireBeginnersKitSeeder(cast(Session, session), cast(Any, _settings()))
+    first_publication = PublicationModel(id=uuid4(), title="First", normalized_title="first")
+    second_publication = PublicationModel(id=uuid4(), title="Second", normalized_title="second")
+
+    seeder._upsert_publication_identifiers(
+        first_publication,
+        {"pid": [{"scheme": "pmc", "value": "PMC8917921"}]},
+        uuid4(),
+    )
+    seeder._upsert_publication_identifiers(
+        second_publication,
+        {"pid": [{"scheme": "pmc", "value": "PMC8917921"}]},
+        uuid4(),
+    )
+
+    identifiers = [
+        item for item in session.added if isinstance(item, ExternalIdentifierModel)
+    ]
+
+    assert len(identifiers) == 1
+    assert identifiers[0].entity_id == first_publication.id
+    assert identifiers[0].identifier_type == "pmc"
+    assert identifiers[0].identifier_value == "PMC8917921"
+
+
+def test_assign_unique_entity_value_skips_conflict_for_unflushed_entities() -> None:
+    session = FakeSeedSession()
+    seeder = OpenAireBeginnersKitSeeder(cast(Session, session), cast(Any, _settings()))
+    first_publication = PublicationModel(title="First", normalized_title="first")
+    second_publication = PublicationModel(title="Second", normalized_title="second")
+
+    first_doi = seeder._assign_unique_entity_value(
+        model=first_publication,
+        value="10.1000/example",
+        current_value=first_publication.doi,
+        field_name="publication.doi",
+        cache=seeder._publication_by_doi,
+        model_class=PublicationModel,
+        model_field="doi",
+    )
+    second_doi = seeder._assign_unique_entity_value(
+        model=second_publication,
+        value="10.1000/example",
+        current_value=second_publication.doi,
+        field_name="publication.doi",
+        cache=seeder._publication_by_doi,
+        model_class=PublicationModel,
+        model_field="doi",
+    )
+
+    assert first_doi == "10.1000/example"
+    assert second_doi is None
+
+
+def test_map_researcher_affiliation_relation_derives_solo_author_affiliation() -> None:
+    publication = PublicationModel(
+        id=uuid4(),
+        title="Solo paper",
+        normalized_title="solo paper",
+        openaire_id="pub-1",
+    )
+    organization = OrganizationModel(
+        id=uuid4(),
+        name="Uni",
+        normalized_name="uni",
+        openaire_id="org-1",
+    )
+    researcher = ResearcherModel(
+        id=uuid4(),
+        full_name="Ada Lovelace",
+        normalized_name="ada lovelace",
+    )
+    author = PublicationAuthorModel(
+        publication_id=publication.id,
+        researcher_id=researcher.id,
+        author_position=1,
+        researcher=researcher,
+    )
+    session = FakeSeedSession(
+        scalars_values=[[author], []],
+        get_values={researcher.id: researcher},
+    )
+    seeder = OpenAireBeginnersKitSeeder(cast(Session, session), cast(Any, _settings()))
+    seeder._publication_by_openaire_id[publication.openaire_id or ""] = publication
+    seeder._organization_by_openaire_id[organization.openaire_id or ""] = organization
+
+    seeder._map_researcher_affiliation_relation(
+        {
+            "reltype": {"name": "hasAuthorInstitution", "type": "affiliation"},
+            "source": "pub-1",
+            "sourceType": "result",
+            "target": "org-1",
+            "targetType": "organization",
+        },
+        uuid4(),
+    )
+
+    affiliations = [
+        item for item in session.added if isinstance(item, ResearcherAffiliationModel)
+    ]
+
+    assert len(affiliations) == 1
+    assert affiliations[0].researcher_id == researcher.id
+    assert affiliations[0].organization_id == organization.id
+    assert affiliations[0].is_primary is True
+    assert researcher.primary_organization_id == organization.id
+
+
+def test_map_researcher_affiliation_relation_skips_ambiguous_multi_author_publication() -> None:
+    publication = PublicationModel(
+        id=uuid4(),
+        title="Team paper",
+        normalized_title="team paper",
+        openaire_id="pub-2",
+    )
+    organization = OrganizationModel(
+        id=uuid4(),
+        name="Uni",
+        normalized_name="uni",
+        openaire_id="org-2",
+    )
+    author_a = PublicationAuthorModel(
+        publication_id=publication.id,
+        researcher_id=uuid4(),
+        author_position=1,
+    )
+    author_b = PublicationAuthorModel(
+        publication_id=publication.id,
+        researcher_id=uuid4(),
+        author_position=2,
+    )
+    session = FakeSeedSession(scalars_values=[[author_a, author_b]])
+    seeder = OpenAireBeginnersKitSeeder(cast(Session, session), cast(Any, _settings()))
+    seeder._publication_by_openaire_id[publication.openaire_id or ""] = publication
+    seeder._organization_by_openaire_id[organization.openaire_id or ""] = organization
+
+    seeder._map_researcher_affiliation_relation(
+        {
+            "reltype": {"name": "hasAuthorInstitution", "type": "affiliation"},
+            "source": "pub-2",
+            "sourceType": "result",
+            "target": "org-2",
+            "targetType": "organization",
+        },
+        uuid4(),
+    )
+
+    assert not [
+        item for item in session.added if isinstance(item, ResearcherAffiliationModel)
+    ]
+    assert all(
+        not isinstance(item, PublicationOrganizationModel)
+        for item in session.added
+    )
+
+
+def test_load_marks_failed_ingestion_run_and_returns_readable_error() -> None:
+    session = FakeSeedSession()
+    seeder = FailingSeeder(cast(Session, session), cast(Any, _settings()))
+
+    try:
+        seeder.load(limit_per_file=200)
+    except HTTPException as exc:
+        detail = exc.detail
+        assert exc.status_code == status.HTTP_409_CONFLICT
+        assert "publication.tar" in detail
+        assert "processed_records=151" in detail
+        assert "limit_per_file=200" in detail
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("Expected load() to raise HTTPException")
+
+    ingestion_run = next(
+        item for item in session.added if isinstance(item, IngestionRunModel)
+    )
+    assert ingestion_run.status == "failed"
+    assert ingestion_run.completed_at is not None
+    assert ingestion_run.notes is not None
+    assert "uq_publication_author_pair" in ingestion_run.notes
+    assert session.commit_calls >= 2
+    assert session.rollback_calls == 1

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -236,7 +236,7 @@ Primary mapping used by the MVP:
 - OpenAIRE `datasource`
   maps to `data_source`, `source_record`
 - OpenAIRE `relation`
-  maps to `publication_organization`, `researcher_affiliation`, plus `source_record`
+  maps to `publication_organization`, conservative derived `researcher_affiliation`, plus `source_record`
 
 The canonical PostgreSQL model intentionally does not mirror each OpenAIRE payload structure directly.
 
@@ -245,6 +245,7 @@ Instead:
 - canonical entities simplify the application layer
 - multiple OpenAIRE identifiers are preserved through first-class columns when operationally important and through `external_identifier` for everything else
 - OpenAIRE relation semantics that matter immediately to the MVP are materialized in dedicated bridge tables
+- `researcher_affiliation` is only derived when a result-organization affiliation relation can be attached to a publication with exactly one canonical author; ambiguous multi-author cases remain unresolved in the seed
 
 ## Query Support
 

--- a/docs/seed-and-api.md
+++ b/docs/seed-and-api.md
@@ -36,6 +36,17 @@ uv run python -m eunigraph.modules.ingestion.application.seed_cli status
 uv run python -m eunigraph.modules.ingestion.application.seed_cli reset
 ```
 
+Current verified behavior:
+- `limit_per_file=200` completes successfully
+- `limit_per_file=500` completes successfully in the current development dataset
+- the CLI `status` command returns the dataclass payload correctly
+
+Seed runtime logging now emits:
+- seed start with dataset path and `limit_per_file`
+- archive phase start, progress and completion
+- processed record counters
+- readable failure context including phase, archive and processed record count
+
 ## Current Seed Scope
 
 The seed currently reads and persists raw provenance from:
@@ -51,11 +62,33 @@ Canonical entities currently populated by the seed:
 - `organization`
 - `publication_author`
 - `publication_organization`
+- `researcher_affiliation` for conservative derived cases
 - `external_identifier`
 - raw provenance tables
 
 Current deliberate limit:
 - `project.tar` and `datasource.tar` are preserved in `source_record` but not yet mapped to canonical tables beyond the logical `data_source` record used for ingestion provenance
+
+Loader robustness notes:
+- raw OpenAIRE payloads remain preserved in `source_record.raw_payload`
+- duplicate `source_record` identifiers inside the same ingestion run are skipped and logged instead of failing the entire seed
+- conflicting external publication identifiers are skipped and logged when the same `(entity_type, identifier_type, identifier_value)` reappears for a different canonical publication in the same run
+- unique-field collisions on canonical entities are handled conservatively during the seed:
+  - `organization.ror_id`
+  - `organization.openaire_id`
+  - `researcher.orcid`
+  - `publication.doi`
+  - `publication.openaire_id`
+  conflicting values are skipped and logged instead of aborting the run
+- bounded canonical text fields are clipped conservatively when source values exceed schema column lengths
+- author links are deduplicated per publication before insert
+- duplicate or invalid author ranks are normalized to the next available `author_position`
+- `publication.language_code` prefers compact codes such as `eng` over verbose labels such as `English`
+- duplicate publication-organization relations inside the same run are skipped and logged
+- `researcher_affiliation` is derived only from `relation.tar` affiliation relations that connect one publication to one organization and can be linked to a publication with exactly one canonical author
+- when a researcher receives exactly one derived organization across the loaded seed slice, that organization is also assigned to `researcher.primary_organization_id`
+- multi-author affiliation relations remain intentionally unresolved because the Beginner's Kit relation does not identify which author matches which organization
+- `limit_per_file` is applied independently per archive, so small partial loads can produce poor cross-archive overlap and therefore under-populate relation-derived tables such as `publication_organization` and `researcher_affiliation`
 
 ## Available APIs
 
@@ -177,6 +210,24 @@ This makes it possible to inspect, for example:
 - only manual API provenance with `source_type=manual_api_entry`
 - all provenance rows linked to one canonical entity with `canonical_entity_id=<uuid>`
 
+## Seed Failure Semantics
+
+The OpenAIRE seed loader should no longer fail with an opaque generic `500` for the known ingestion-path issues addressed in the MVP.
+
+Current behavior:
+- `400` for dataset path or archive validation problems, and for archive/parsing failures
+- `409` for database persistence conflicts or schema-bound data issues encountered during ingestion
+- `503` for resource exhaustion such as `MemoryError`
+
+Readable seed failures include:
+- failure category
+- execution stage
+- archive name when available
+- processed record count when available
+- `limit_per_file` when set
+
+Failed ingestion runs are also persisted with `status=failed`, `completed_at`, and contextual notes so the last run status remains inspectable after rollback.
+
 ## Coauthorship Materialization
 
 The coauthorship graph is materialized from canonical PostgreSQL data and then served from persisted artifacts.
@@ -270,7 +321,9 @@ The Qdrant payload is intentionally publication-centric. It includes the semanti
 - no automatic download of the Beginner's Kit
 - no canonical `project` API yet
 - no canonical `datasource` entity API for OpenAIRE datasource records yet
-- relation-to-affiliation mapping is intentionally conservative; publication-organization mapping is the primary relation materialized from `relation.tar` in the MVP
+- relation-to-affiliation mapping remains intentionally conservative:
+  - `publication_organization` is materialized directly from result-organization relations
+  - `researcher_affiliation` is derived only for unambiguous solo-author publication cases
 - manual provenance for `researcher` and `organization` is stored in `source_record` but those entities do not yet have a direct foreign key to the latest provenance row
 - coauthorship graph rebuilds are explicit API operations; there is no automatic rebuild trigger yet
 - subgraph filtering currently uses materialized node metadata and edge weights, not dynamic graph recomputation


### PR DESCRIPTION
- Implement unit tests for OpenAIREBeginnersKitSeeder to ensure correct handling of publication authors, identifiers, and researcher affiliations.
- Introduce a FakeSeedSession for simulating database interactions during tests.
- Modify seed_cli.py to use asdict for returning seeder status.
- Update documentation to reflect changes in seed behavior, including logging improvements and error semantics.
- Clarify the conditions under which researcher affiliations are derived and the handling of duplicate identifiers during ingestion.