### PR TITLE
feat: Update EUNICE seed to constrain publications to the year 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,18 @@ This is the path the project is now optimized around for:
 - end-to-end demo preparation from the admin console
 
 The workflow uses the OpenAIRE Graph API v2 with:
-- `GET /graph/v2/researchProducts?relCommunityId=eunice&type=publication`
+- `GET /graph/v2/researchProducts?relCommunityId=eunice&type=publication&fromPublicationDate=2026-01-01&toPublicationDate=2026-12-31`
 
 It imports:
 - publications
 - authors/researchers
 - organizations embedded in publication metadata
 - canonical relations such as `publication_author`, `publication_organization` and derived `researcher_affiliation`
+
+Operational notes:
+- the current demo seed is intentionally limited to **2026 publications only**
+- the loader uses OpenAIRE Graph API v2 cursor pagination
+- publications are persisted in batches per API page to keep backend memory and SQLAlchemy session growth under control on larger loads
 
 Main entry points:
 - frontend admin console: `/admin/operations`

--- a/backend/src/eunigraph/api/routers/admin_eunice_seed.py
+++ b/backend/src/eunigraph/api/routers/admin_eunice_seed.py
@@ -65,7 +65,5 @@ def load_eunice_seed(
     return OpenAireGraphEuniceSeedLoadResponse.model_validate(
         OpenAireGraphEuniceSeeder(session, settings).load(
             max_publications=payload.max_publications,
-            publication_year_from=payload.publication_year_from,
-            publication_year_to=payload.publication_year_to,
         ),
     )

--- a/backend/src/eunigraph/api/routers/coauthorship.py
+++ b/backend/src/eunigraph/api/routers/coauthorship.py
@@ -26,8 +26,9 @@ router = APIRouter(
 )
 DB_SESSION = Depends(get_db_session)
 APP_SETTINGS = Depends(get_app_settings)
-MAX_NODES_QUERY = Query(default=None, ge=1, le=2500)
+MAX_NODES_QUERY = Query(default=None, ge=1)
 MIN_EDGE_WEIGHT_QUERY = Query(default=None, ge=1, le=1000)
+MIN_DEGREE_QUERY = Query(default=None, ge=0, le=10000)
 
 
 def _service(session: Session, settings: Settings) -> CoauthorshipGraphService:
@@ -102,6 +103,8 @@ def get_coauthorship_subgraph(
     organization_id: UUID | None = None,
     max_nodes: int | None = MAX_NODES_QUERY,
     min_edge_weight: int | None = MIN_EDGE_WEIGHT_QUERY,
+    min_degree: int | None = MIN_DEGREE_QUERY,
+    largest_component_only: bool = False,
     community_id: int | None = Query(default=None, ge=0),
     session: Session = DB_SESSION,
     settings: Settings = APP_SETTINGS,
@@ -111,6 +114,8 @@ def get_coauthorship_subgraph(
         organization_id=organization_id,
         max_nodes=max_nodes,
         min_edge_weight=min_edge_weight,
+        min_degree=min_degree,
+        largest_component_only=largest_component_only,
         community_id=community_id,
     )
     return CoauthorshipGraphPayloadResponse(**payload)

--- a/backend/src/eunigraph/api/routers/semantic_graph.py
+++ b/backend/src/eunigraph/api/routers/semantic_graph.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import asdict
 from uuid import UUID
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 
@@ -108,9 +108,11 @@ def get_semantic_subgraph(
     publication_id: UUID | None = None,
     organization_id: UUID | None = None,
     publication_year: int | None = None,
-    max_nodes: int | None = None,
-    min_edge_weight: float | None = None,
-    community_id: int | None = None,
+    max_nodes: int | None = Query(default=None, ge=1),
+    min_edge_weight: float | None = Query(default=None, ge=0),
+    min_degree: int | None = Query(default=None, ge=0, le=10000),
+    largest_component_only: bool = False,
+    community_id: int | None = Query(default=None, ge=0),
     session: Session = DB_SESSION,
     settings: Settings = APP_SETTINGS,
 ) -> SemanticGraphPayloadResponse:
@@ -120,6 +122,8 @@ def get_semantic_subgraph(
         publication_year=publication_year,
         max_nodes=max_nodes,
         min_edge_weight=min_edge_weight,
+        min_degree=min_degree,
+        largest_component_only=largest_component_only,
         community_id=community_id,
     )
     return SemanticGraphPayloadResponse(**payload)

--- a/backend/src/eunigraph/api/schemas/admin.py
+++ b/backend/src/eunigraph/api/schemas/admin.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field
 
 
 class OpenAireSeedLoadRequest(BaseModel):
@@ -44,6 +44,10 @@ class OpenAireGraphEuniceSeedStatusResponse(BaseModel):
     api_base_url: str
     community_id: str
     product_type: str
+    publication_date_from: str
+    publication_date_to: str
+    pagination_mode: str
+    page_size: int
     default_max_publications: int
     table_counts: dict[str, int]
     latest_ingestion_run_id: str | None
@@ -52,23 +56,15 @@ class OpenAireGraphEuniceSeedStatusResponse(BaseModel):
 
 class OpenAireGraphEuniceSeedLoadRequest(BaseModel):
     max_publications: int | None = Field(default=None, ge=1, le=2000)
-    publication_year_from: int | None = Field(default=None, ge=1000, le=3000)
-    publication_year_to: int | None = Field(default=None, ge=1000, le=3000)
-
-    @model_validator(mode="after")
-    def validate_year_range(self) -> OpenAireGraphEuniceSeedLoadRequest:
-        if (
-            self.publication_year_from is not None
-            and self.publication_year_to is not None
-            and self.publication_year_from > self.publication_year_to
-        ):
-            raise ValueError("publication_year_from cannot be greater than publication_year_to")
-        return self
 
 
 class OpenAireGraphEuniceSeedLoadResponse(BaseModel):
     api_base_url: str
     community_id: str
+    publication_date_from: str
+    publication_date_to: str
+    pagination_mode: str
+    page_size: int
     ingestion_run_id: str | None
     max_publications: int | None
     publication_records_processed: int

--- a/backend/src/eunigraph/core/config.py
+++ b/backend/src/eunigraph/core/config.py
@@ -58,7 +58,7 @@ class Settings(BaseSettings):
         alias="OPENAIRE_GRAPH_API_TIMEOUT_SECONDS",
     )
     openaire_graph_api_page_size: int = Field(
-        default=25,
+        default=100,
         alias="OPENAIRE_GRAPH_API_PAGE_SIZE",
     )
     openaire_eunice_seed_max_publications: int = Field(

--- a/backend/src/eunigraph/modules/coauthorship/application/services.py
+++ b/backend/src/eunigraph/modules/coauthorship/application/services.py
@@ -166,6 +166,8 @@ class CoauthorshipGraphService:
         organization_id: UUID | None = None,
         max_nodes: int | None = None,
         min_edge_weight: int | None = None,
+        min_degree: int | None = None,
+        largest_component_only: bool = False,
         community_id: int | None = None,
     ) -> dict[str, Any]:
         payload = self._load_materialized_payload()
@@ -175,6 +177,8 @@ class CoauthorshipGraphService:
             organization_id=organization_id,
             max_nodes=max_nodes,
             min_edge_weight=min_edge_weight,
+            min_degree=min_degree,
+            largest_component_only=largest_component_only,
             community_id=community_id,
         )
 
@@ -745,6 +749,8 @@ class CoauthorshipGraphService:
         organization_id: UUID | None,
         max_nodes: int | None,
         min_edge_weight: int | None,
+        min_degree: int | None = None,
+        largest_component_only: bool = False,
         community_id: int | None,
     ) -> dict[str, Any]:
         nodes = list(payload["nodes"])
@@ -764,6 +770,13 @@ class CoauthorshipGraphService:
                 for node in nodes
                 if node.get("primary_organization_id") == organization_id_str
             }
+
+        if min_degree is not None:
+            selected_node_ids, edges = self._apply_min_degree_filter(
+                selected_node_ids=selected_node_ids,
+                edges=edges,
+                min_degree=min_degree,
+            )
 
         if researcher_id is not None:
             researcher_id_str = str(researcher_id)
@@ -808,11 +821,28 @@ class CoauthorshipGraphService:
             )
             selected_node_ids = {node["id"] for node in ranked_nodes[:max_nodes]}
 
+        if largest_component_only:
+            selected_node_ids = self._largest_component_node_ids(
+                selected_node_ids=selected_node_ids,
+                edges=edges,
+            )
+
         filtered_nodes = [node for node in nodes if node["id"] in selected_node_ids]
         filtered_edges = [
             edge
             for edge in edges
             if edge["source"] in selected_node_ids and edge["target"] in selected_node_ids
+        ]
+        filtered_nodes = [node for node in nodes if node["id"] in selected_node_ids]
+        visualization_edges = [
+            {
+                **edge,
+                # The graph explorer does not need the full publication-id list for every edge.
+                # Returning an empty list keeps the subgraph payload much lighter for
+                # large views while preserving counts and temporal metadata used in the UI.
+                "shared_publication_ids": [],
+            }
+            for edge in filtered_edges
         ]
 
         return {
@@ -840,9 +870,95 @@ class CoauthorshipGraphService:
                 "graph_version": payload["summary"]["graph_version"],
             },
             "nodes": filtered_nodes,
-            "edges": filtered_edges,
+            "edges": visualization_edges,
             "data_snapshot": payload["data_snapshot"],
         }
+
+    def _apply_min_degree_filter(
+        self,
+        *,
+        selected_node_ids: set[str],
+        edges: list[dict[str, Any]],
+        min_degree: int,
+    ) -> tuple[set[str], list[dict[str, Any]]]:
+        if min_degree <= 0:
+            return selected_node_ids, edges
+        filtered_edges = [
+            edge
+            for edge in edges
+            if edge["source"] in selected_node_ids and edge["target"] in selected_node_ids
+        ]
+        degrees = self._compute_filtered_node_metrics(
+            selected_node_ids=selected_node_ids,
+            edges=filtered_edges,
+        )
+        retained_node_ids = {
+            node_id
+            for node_id, metrics in degrees.items()
+            if metrics["degree"] >= min_degree
+        }
+        retained_edges = [
+            edge
+            for edge in filtered_edges
+            if edge["source"] in retained_node_ids and edge["target"] in retained_node_ids
+        ]
+        return retained_node_ids, retained_edges
+
+    def _largest_component_node_ids(
+        self,
+        *,
+        selected_node_ids: set[str],
+        edges: list[dict[str, Any]],
+    ) -> set[str]:
+        if not selected_node_ids:
+            return set()
+        adjacency: dict[str, set[str]] = {node_id: set() for node_id in selected_node_ids}
+        for edge in edges:
+            source = edge["source"]
+            target = edge["target"]
+            if source in adjacency and target in adjacency:
+                adjacency[source].add(target)
+                adjacency[target].add(source)
+
+        visited: set[str] = set()
+        largest_component: set[str] = set()
+        for node_id in selected_node_ids:
+            if node_id in visited:
+                continue
+            stack = [node_id]
+            component: set[str] = set()
+            while stack:
+                current = stack.pop()
+                if current in visited:
+                    continue
+                visited.add(current)
+                component.add(current)
+                stack.extend(adjacency[current] - visited)
+            if len(component) > len(largest_component):
+                largest_component = component
+        return largest_component
+
+    def _compute_filtered_node_metrics(
+        self,
+        *,
+        selected_node_ids: set[str],
+        edges: list[dict[str, Any]],
+    ) -> dict[str, dict[str, int | float]]:
+        metrics = {
+            node_id: {"degree": 0, "strength": 0.0}
+            for node_id in selected_node_ids
+        }
+        for edge in edges:
+            source = edge["source"]
+            target = edge["target"]
+            weight = float(edge["weight"])
+            if source in metrics:
+                metrics[source]["degree"] = int(metrics[source]["degree"]) + 1
+                metrics[source]["strength"] = float(metrics[source]["strength"]) + weight
+            if target in metrics:
+                metrics[target]["degree"] = int(metrics[target]["degree"]) + 1
+                metrics[target]["strength"] = float(metrics[target]["strength"]) + weight
+        return metrics
 
     def _load_graph_tool(self) -> dict[str, Any]:
         try:

--- a/backend/src/eunigraph/modules/ingestion/application/openaire_graph_eunice.py
+++ b/backend/src/eunigraph/modules/ingestion/application/openaire_graph_eunice.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 from dataclasses import dataclass
@@ -41,6 +42,9 @@ OPENAIRE_GRAPH_EUNICE_SOURCE_NAME = "OpenAIRE Graph EUNICE Seed"
 OPENAIRE_GRAPH_EUNICE_SOURCE_TYPE = "openaire_graph_eunice"
 OPENAIRE_GRAPH_EUNICE_COMMUNITY_ID = "eunice"
 OPENAIRE_GRAPH_EUNICE_PRODUCT_TYPE = "publication"
+OPENAIRE_GRAPH_EUNICE_PUBLICATION_DATE_FROM = "2026-01-01"
+OPENAIRE_GRAPH_EUNICE_PUBLICATION_DATE_TO = "2026-12-31"
+OPENAIRE_GRAPH_EUNICE_PAGINATION_MODE = "cursor"
 
 
 @dataclass(frozen=True, slots=True)
@@ -48,6 +52,10 @@ class EUNICESeedStatus:
     api_base_url: str
     community_id: str
     product_type: str
+    publication_date_from: str
+    publication_date_to: str
+    pagination_mode: str
+    page_size: int
     default_max_publications: int
     table_counts: dict[str, int]
     latest_ingestion_run_id: str | None
@@ -77,53 +85,64 @@ class OpenAireGraphApiClient:
         payload = self._get_json("/v1/organizations", {"pageSize": str(page_size), **params})
         return self._extract_results(payload, path="/v1/organizations")
 
-    def iter_research_products(
+    def iter_research_product_pages(
         self,
         *,
         max_results: int | None,
         page_size: int,
         **params: str,
-    ) -> list[dict[str, Any]]:
-        page = 1
+    ) -> Any:
         yielded = 0
-        results: list[dict[str, Any]] = []
         effective_page_size = max(1, min(page_size, 100))
+        cursor = "*"
+        page = 1
+        use_cursor = True
 
         while True:
             remaining = None if max_results is None else max_results - yielded
             if remaining is not None and remaining <= 0:
-                return results
+                return
 
             current_page_size = (
                 min(effective_page_size, remaining)
                 if remaining is not None
                 else effective_page_size
             )
-            payload = self._get_json(
-                "/v2/researchProducts",
-                {
-                    "page": str(page),
-                    "pageSize": str(current_page_size),
-                    **params,
-                },
-            )
+            query_params = {"pageSize": str(current_page_size), **params}
+            if use_cursor:
+                query_params["cursor"] = cursor
+            else:
+                query_params["page"] = str(page)
+
+            payload = self._get_json("/v2/researchProducts", query_params)
             page_results = self._extract_results(payload, path="/v2/researchProducts")
             if not page_results:
-                return results
+                return
 
-            results.extend(page_results)
+            yield page_results
             yielded += len(page_results)
 
             header = payload.get("header") if isinstance(payload, dict) else None
+            next_cursor = self._extract_next_cursor(header)
             total_found = self._extract_positive_int(header, "numFound")
+            if max_results is not None and yielded >= max_results:
+                return
+            if len(page_results) < current_page_size:
+                return
+            if use_cursor and next_cursor:
+                cursor = next_cursor
+                continue
+            if use_cursor:
+                use_cursor = False
+                page = 2
+                continue
+            if total_found is not None and yielded >= total_found:
+                return
             page_size_value = self._extract_positive_int(header, "pageSize") or current_page_size
             current_page = self._extract_positive_int(header, "page") or page
             if total_found is not None and current_page * page_size_value >= total_found:
-                return results
-            if len(page_results) < current_page_size:
-                return results
-
-            page += 1
+                return
+            page = current_page + 1
 
     def _get_json(self, path: str, params: dict[str, str]) -> dict[str, Any]:
         query = parse.urlencode({key: value for key, value in params.items() if value})
@@ -237,6 +256,15 @@ class OpenAireGraphApiClient:
             return None
         return parsed if parsed >= 0 else None
 
+    def _extract_next_cursor(self, payload: Any) -> str | None:
+        if not isinstance(payload, dict):
+            return None
+        value = payload.get("nextCursor")
+        if not isinstance(value, str):
+            return None
+        normalized = value.strip()
+        return normalized or None
+
 
 class OpenAireGraphEuniceSeeder(OpenAireBeginnersKitSeeder):
     def __init__(self, session: Session, settings: Settings) -> None:
@@ -245,7 +273,7 @@ class OpenAireGraphEuniceSeeder(OpenAireBeginnersKitSeeder):
             base_url=settings.openaire_graph_api_base_url,
             timeout_seconds=settings.openaire_graph_api_timeout_seconds,
         )
-        self._affiliation_candidate_orgs_by_publication: dict[UUID, set[UUID]] = {}
+        self._source_record_refs: dict[tuple[UUID, str, str], tuple[UUID, str]] = {}
 
     def get_status(self) -> EUNICESeedStatus:  # type: ignore[override]
         latest_run = self.session.scalar(
@@ -259,6 +287,10 @@ class OpenAireGraphEuniceSeeder(OpenAireBeginnersKitSeeder):
             api_base_url=self._api.base_url,
             community_id=OPENAIRE_GRAPH_EUNICE_COMMUNITY_ID,
             product_type=OPENAIRE_GRAPH_EUNICE_PRODUCT_TYPE,
+            publication_date_from=OPENAIRE_GRAPH_EUNICE_PUBLICATION_DATE_FROM,
+            publication_date_to=OPENAIRE_GRAPH_EUNICE_PUBLICATION_DATE_TO,
+            pagination_mode=OPENAIRE_GRAPH_EUNICE_PAGINATION_MODE,
+            page_size=max(1, min(self.settings.openaire_graph_api_page_size, 100)),
             default_max_publications=self.settings.openaire_eunice_seed_max_publications,
             table_counts=self._snapshot_table_counts(),
             latest_ingestion_run_id=str(latest_run.id) if latest_run else None,
@@ -270,8 +302,6 @@ class OpenAireGraphEuniceSeeder(OpenAireBeginnersKitSeeder):
         *,
         limit_per_file: int | None = None,
         max_publications: int | None = None,
-        publication_year_from: int | None = None,
-        publication_year_to: int | None = None,
     ) -> dict[str, int | str | None]:
         if max_publications is None and limit_per_file is not None:
             max_publications = limit_per_file
@@ -280,67 +310,91 @@ class OpenAireGraphEuniceSeeder(OpenAireBeginnersKitSeeder):
             if max_publications is not None
             else self.settings.openaire_eunice_seed_max_publications
         )
+        effective_page_size = max(1, min(self.settings.openaire_graph_api_page_size, 100))
         before_counts = self._snapshot_table_counts()
         data_source = self._get_or_create_logical_source()
+        data_source_id = data_source.id
         logger.info(
             "OpenAIRE Graph EUNICE seed started api_base_url=%s community_id=%s "
-            "product_type=%s max_publications=%s publication_year_from=%s publication_year_to=%s",
+            "product_type=%s max_publications=%s publication_date_from=%s publication_date_to=%s "
+            "page_size=%s pagination_mode=%s",
             self._api.base_url,
             OPENAIRE_GRAPH_EUNICE_COMMUNITY_ID,
             OPENAIRE_GRAPH_EUNICE_PRODUCT_TYPE,
             max_results,
-            publication_year_from,
-            publication_year_to,
+            OPENAIRE_GRAPH_EUNICE_PUBLICATION_DATE_FROM,
+            OPENAIRE_GRAPH_EUNICE_PUBLICATION_DATE_TO,
+            effective_page_size,
+            OPENAIRE_GRAPH_EUNICE_PAGINATION_MODE,
         )
 
         ingestion_run = IngestionRunModel(
-            data_source_id=data_source.id,
+            data_source_id=data_source_id,
             status="running",
             triggered_by="admin-api",
             raw_config={
                 "community_id": OPENAIRE_GRAPH_EUNICE_COMMUNITY_ID,
                 "product_type": OPENAIRE_GRAPH_EUNICE_PRODUCT_TYPE,
                 "max_publications": max_results,
-                "publication_year_from": publication_year_from,
-                "publication_year_to": publication_year_to,
+                "publication_date_from": OPENAIRE_GRAPH_EUNICE_PUBLICATION_DATE_FROM,
+                "publication_date_to": OPENAIRE_GRAPH_EUNICE_PUBLICATION_DATE_TO,
+                "page_size": effective_page_size,
+                "pagination_mode": OPENAIRE_GRAPH_EUNICE_PAGINATION_MODE,
             },
         )
         self.session.add(ingestion_run)
         self.session.flush()
+        ingestion_run_id = ingestion_run.id
         self.session.commit()
 
-        processed_publication_ids: set[UUID] = set()
+        processed_publications = 0
         ambiguous_publications = 0
+        batch_number = 0
         try:
-            publication_payloads = self._api.iter_research_products(
+            for publication_payloads in self._api.iter_research_product_pages(
                 max_results=max_results,
-                page_size=self.settings.openaire_graph_api_page_size,
+                page_size=effective_page_size,
                 relCommunityId=OPENAIRE_GRAPH_EUNICE_COMMUNITY_ID,
                 type=OPENAIRE_GRAPH_EUNICE_PRODUCT_TYPE,
                 sortBy="publicationDate DESC",
-                fromPublicationDate=str(publication_year_from) if publication_year_from else "",
-                toPublicationDate=str(publication_year_to) if publication_year_to else "",
-            )
-            self._process_publication_payloads(
-                publication_payloads,
-                data_source_id=data_source.id,
-                ingestion_run_id=ingestion_run.id,
-                processed_publication_ids=processed_publication_ids,
-            )
+                fromPublicationDate=OPENAIRE_GRAPH_EUNICE_PUBLICATION_DATE_FROM,
+                toPublicationDate=OPENAIRE_GRAPH_EUNICE_PUBLICATION_DATE_TO,
+            ):
+                batch_number += 1
+                batch_processed, batch_ambiguous = self._process_publication_payloads(
+                    publication_payloads,
+                    data_source_id=data_source_id,
+                    ingestion_run_id=ingestion_run_id,
+                )
+                processed_publications += batch_processed
+                ambiguous_publications += batch_ambiguous
+                logger.info(
+                    "OpenAIRE Graph EUNICE seed committing batch ingestion_run_id=%s "
+                    "batch_number=%s batch_size=%s processed_publications=%s "
+                    "ambiguous_publications=%s",
+                    ingestion_run_id,
+                    batch_number,
+                    batch_processed,
+                    processed_publications,
+                    ambiguous_publications,
+                )
+                self.session.commit()
+                self._reset_batch_state()
 
-            ambiguous_publications = self._materialize_candidate_affiliations()
-            ingestion_run.status = "completed"
-            ingestion_run.completed_at = datetime.now(UTC)
+            persisted_run = self.session.get(IngestionRunModel, ingestion_run_id)
+            if persisted_run is not None:
+                persisted_run.status = "completed"
+                persisted_run.completed_at = datetime.now(UTC)
             self.session.commit()
         except SeedLoadError as exc:
             self.session.rollback()
             logger.warning(
                 "OpenAIRE Graph EUNICE seed failed ingestion_run_id=%s detail=%s",
-                ingestion_run.id,
+                ingestion_run_id,
                 exc.detail(),
                 exc_info=True,
             )
-            self._mark_ingestion_run_failed(ingestion_run.id, exc.detail())
+            self._mark_ingestion_run_failed(ingestion_run_id, exc.detail())
             raise exc.to_http_exception() from exc
         except SQLAlchemyError as exc:
             self.session.rollback()
@@ -352,9 +406,9 @@ class OpenAireGraphEuniceSeeder(OpenAireBeginnersKitSeeder):
             )
             logger.exception(
                 "OpenAIRE Graph EUNICE seed database failure ingestion_run_id=%s",
-                ingestion_run.id,
+                ingestion_run_id,
             )
-            self._mark_ingestion_run_failed(ingestion_run.id, seed_error.detail())
+            self._mark_ingestion_run_failed(ingestion_run_id, seed_error.detail())
             raise seed_error.to_http_exception() from exc
         except Exception as exc:  # pragma: no cover - defensive path
             self.session.rollback()
@@ -366,20 +420,26 @@ class OpenAireGraphEuniceSeeder(OpenAireBeginnersKitSeeder):
             )
             logger.exception(
                 "OpenAIRE Graph EUNICE seed unexpected failure ingestion_run_id=%s",
-                ingestion_run.id,
+                ingestion_run_id,
             )
-            self._mark_ingestion_run_failed(ingestion_run.id, seed_error.detail())
+            self._mark_ingestion_run_failed(ingestion_run_id, seed_error.detail())
             raise seed_error.to_http_exception() from exc
 
         after_counts = self._snapshot_table_counts()
-        data_source.base_url = self._api.active_base_url
+        persisted_source = self.session.get(DataSourceModel, data_source_id)
+        if persisted_source is not None:
+            persisted_source.base_url = self._api.active_base_url
         self.session.commit()
         return {
             "api_base_url": self._api.active_base_url,
             "community_id": OPENAIRE_GRAPH_EUNICE_COMMUNITY_ID,
-            "ingestion_run_id": str(ingestion_run.id),
+            "publication_date_from": OPENAIRE_GRAPH_EUNICE_PUBLICATION_DATE_FROM,
+            "publication_date_to": OPENAIRE_GRAPH_EUNICE_PUBLICATION_DATE_TO,
+            "pagination_mode": OPENAIRE_GRAPH_EUNICE_PAGINATION_MODE,
+            "page_size": effective_page_size,
+            "ingestion_run_id": str(ingestion_run_id),
             "max_publications": max_results,
-            "publication_records_processed": len(processed_publication_ids),
+            "publication_records_processed": processed_publications,
             "new_organizations": after_counts["organization"] - before_counts["organization"],
             "new_researchers": after_counts["researcher"] - before_counts["researcher"],
             "new_publications": after_counts["publication"] - before_counts["publication"],
@@ -400,8 +460,9 @@ class OpenAireGraphEuniceSeeder(OpenAireBeginnersKitSeeder):
         *,
         data_source_id: UUID,
         ingestion_run_id: UUID,
-        processed_publication_ids: set[UUID],
-    ) -> None:
+    ) -> tuple[int, int]:
+        processed = 0
+        ambiguous = 0
         for publication_payload in publication_payloads:
             transformed_publication = self._to_legacy_publication_payload(publication_payload)
             source_identifier = self._payload_identifier(transformed_publication)
@@ -426,12 +487,14 @@ class OpenAireGraphEuniceSeeder(OpenAireBeginnersKitSeeder):
                 ingestion_run_id=ingestion_run_id,
                 source_record_id=source_record.id,
             )
-            if organization_ids:
-                self._affiliation_candidate_orgs_by_publication.setdefault(
-                    publication.id,
-                    set(),
-                ).update(organization_ids)
-            processed_publication_ids.add(publication.id)
+            if self._materialize_candidate_affiliations_for_publication(
+                publication=publication,
+                organization_ids=organization_ids,
+            ):
+                ambiguous += 1
+            processed += 1
+
+        return processed, ambiguous
 
     def _upsert_publication_organizations(
         self,
@@ -477,37 +540,102 @@ class OpenAireGraphEuniceSeeder(OpenAireBeginnersKitSeeder):
 
         return linked_organization_ids
 
-    def _materialize_candidate_affiliations(self) -> int:
-        ambiguous_publications = 0
+    def _materialize_candidate_affiliations_for_publication(
+        self,
+        *,
+        publication: PublicationModel,
+        organization_ids: set[UUID],
+    ) -> bool:
+        if not organization_ids:
+            return False
+        if len(organization_ids) != 1:
+            return True
+        if publication.canonical_source_record_id is None:
+            return False
 
-        for (
-            publication_id,
-            organization_ids,
-        ) in self._affiliation_candidate_orgs_by_publication.items():
-            if len(organization_ids) != 1:
-                ambiguous_publications += 1
-                continue
-
-            publication = self.session.get(PublicationModel, publication_id)
-            if publication is None or publication.canonical_source_record_id is None:
-                continue
-
-            organization_id = next(iter(organization_ids))
-            authors = list(
-                self.session.scalars(
-                    select(PublicationAuthorModel).where(
-                        PublicationAuthorModel.publication_id == publication_id,
-                    )
+        organization_id = next(iter(organization_ids))
+        authors = list(
+            self.session.scalars(
+                select(PublicationAuthorModel).where(
+                    PublicationAuthorModel.publication_id == publication.id,
                 )
             )
-            for author in authors:
-                self._upsert_researcher_affiliation(
-                    researcher_id=author.researcher_id,
-                    organization_id=organization_id,
-                    source_record_id=publication.canonical_source_record_id,
-                )
+        )
+        for author in authors:
+            self._upsert_researcher_affiliation(
+                researcher_id=author.researcher_id,
+                organization_id=organization_id,
+                source_record_id=publication.canonical_source_record_id,
+            )
+        return False
 
-        return ambiguous_publications
+    def _create_source_record(
+        self,
+        *,
+        data_source_id: UUID,
+        ingestion_run_id: UUID,
+        entity_type: str,
+        source_identifier: str,
+        payload: dict[str, Any],
+    ) -> SourceRecordModel:
+        checksum = self._payload_checksum(payload)
+        cache_key = (ingestion_run_id, entity_type, source_identifier)
+        cached_ref = self._source_record_refs.get(cache_key)
+        if cached_ref is not None:
+            cached_record_id, cached_checksum = cached_ref
+            if cached_checksum != checksum:
+                logger.warning(
+                    "OpenAIRE Graph EUNICE seed encountered duplicate source record with "
+                    "changed payload "
+                    "ingestion_run_id=%s entity_type=%s source_identifier=%s",
+                    ingestion_run_id,
+                    entity_type,
+                    source_identifier,
+                )
+            else:
+                logger.info(
+                    "OpenAIRE Graph EUNICE seed reused duplicate source record "
+                    "ingestion_run_id=%s entity_type=%s source_identifier=%s",
+                    ingestion_run_id,
+                    entity_type,
+                    source_identifier,
+                )
+            cached_record = self.session.get(SourceRecordModel, cached_record_id)
+            if cached_record is not None:
+                return cached_record
+
+        record = SourceRecordModel(
+            data_source_id=data_source_id,
+            ingestion_run_id=ingestion_run_id,
+            entity_type=entity_type,
+            source_identifier=source_identifier,
+            checksum=checksum,
+            raw_payload=payload,
+        )
+        self.session.add(record)
+        self.session.flush()
+        self._source_record_refs[cache_key] = (record.id, checksum)
+        return record
+
+    def _payload_checksum(self, payload: dict[str, Any]) -> str:
+        return hashlib.sha256(
+            json.dumps(payload, sort_keys=True).encode("utf-8"),
+        ).hexdigest()
+
+    def _reset_batch_state(self) -> None:
+        self._source_record_cache.clear()
+        self._organization_by_openaire_id.clear()
+        self._organization_by_ror_id.clear()
+        self._organization_by_normalized_name.clear()
+        self._researcher_by_orcid.clear()
+        self._researcher_by_normalized_name.clear()
+        self._publication_by_openaire_id.clear()
+        self._publication_by_doi.clear()
+        self._publication_by_title_year.clear()
+        self._researcher_affiliations_by_researcher.clear()
+        expunge_all = getattr(self.session, "expunge_all", None)
+        if callable(expunge_all):
+            expunge_all()
 
     def _map_publication_affiliation_relation(
         self,

--- a/backend/src/eunigraph/modules/semantic_graph/application/services.py
+++ b/backend/src/eunigraph/modules/semantic_graph/application/services.py
@@ -209,6 +209,8 @@ class SemanticGraphService:
         publication_year: int | None = None,
         max_nodes: int | None = None,
         min_edge_weight: float | None = None,
+        min_degree: int | None = None,
+        largest_component_only: bool = False,
         community_id: int | None = None,
     ) -> dict[str, Any]:
         payload = self._load_materialized_payload()
@@ -219,6 +221,8 @@ class SemanticGraphService:
             publication_year=publication_year,
             max_nodes=max_nodes,
             min_edge_weight=min_edge_weight,
+            min_degree=min_degree,
+            largest_component_only=largest_component_only,
             community_id=community_id,
         )
 
@@ -927,6 +931,8 @@ class SemanticGraphService:
         publication_year: int | None,
         max_nodes: int | None,
         min_edge_weight: float | None,
+        min_degree: int | None = None,
+        largest_component_only: bool = False,
         community_id: int | None,
     ) -> dict[str, Any]:
         nodes = list(payload["nodes"])
@@ -952,6 +958,13 @@ class SemanticGraphService:
                 for node in nodes
                 if organization_id_str in node.get("organization_ids", [])
             }
+
+        if min_degree is not None:
+            selected_node_ids, edges = self._apply_min_degree_filter(
+                selected_node_ids=selected_node_ids,
+                edges=edges,
+                min_degree=min_degree,
+            )
 
         if publication_id is not None:
             publication_id_str = str(publication_id)
@@ -988,12 +1001,19 @@ class SemanticGraphService:
             )
             selected_node_ids = {node["id"] for node in ranked_nodes[:max_nodes]}
 
+        if largest_component_only:
+            selected_node_ids = self._largest_component_node_ids(
+                selected_node_ids=selected_node_ids,
+                edges=edges,
+            )
+
         filtered_nodes = [node for node in nodes if node["id"] in selected_node_ids]
         filtered_edges = [
             edge
             for edge in edges
             if edge["source"] in selected_node_ids and edge["target"] in selected_node_ids
         ]
+        filtered_nodes = [node for node in nodes if node["id"] in selected_node_ids]
         return {
             "build_id": payload["build_id"],
             "graph_type": payload["graph_type"],
@@ -1022,6 +1042,92 @@ class SemanticGraphService:
             "edges": filtered_edges,
             "data_snapshot": payload["data_snapshot"],
         }
+
+    def _apply_min_degree_filter(
+        self,
+        *,
+        selected_node_ids: set[str],
+        edges: list[dict[str, Any]],
+        min_degree: int,
+    ) -> tuple[set[str], list[dict[str, Any]]]:
+        if min_degree <= 0:
+            return selected_node_ids, edges
+        filtered_edges = [
+            edge
+            for edge in edges
+            if edge["source"] in selected_node_ids and edge["target"] in selected_node_ids
+        ]
+        degrees = self._compute_filtered_node_metrics(
+            selected_node_ids=selected_node_ids,
+            edges=filtered_edges,
+        )
+        retained_node_ids = {
+            node_id
+            for node_id, metrics in degrees.items()
+            if metrics["degree"] >= min_degree
+        }
+        retained_edges = [
+            edge
+            for edge in filtered_edges
+            if edge["source"] in retained_node_ids and edge["target"] in retained_node_ids
+        ]
+        return retained_node_ids, retained_edges
+
+    def _largest_component_node_ids(
+        self,
+        *,
+        selected_node_ids: set[str],
+        edges: list[dict[str, Any]],
+    ) -> set[str]:
+        if not selected_node_ids:
+            return set()
+        adjacency: dict[str, set[str]] = {node_id: set() for node_id in selected_node_ids}
+        for edge in edges:
+            source = edge["source"]
+            target = edge["target"]
+            if source in adjacency and target in adjacency:
+                adjacency[source].add(target)
+                adjacency[target].add(source)
+
+        visited: set[str] = set()
+        largest_component: set[str] = set()
+        for node_id in selected_node_ids:
+            if node_id in visited:
+                continue
+            stack = [node_id]
+            component: set[str] = set()
+            while stack:
+                current = stack.pop()
+                if current in visited:
+                    continue
+                visited.add(current)
+                component.add(current)
+                stack.extend(adjacency[current] - visited)
+            if len(component) > len(largest_component):
+                largest_component = component
+        return largest_component
+
+    def _compute_filtered_node_metrics(
+        self,
+        *,
+        selected_node_ids: set[str],
+        edges: list[dict[str, Any]],
+    ) -> dict[str, dict[str, int | float]]:
+        metrics = {
+            node_id: {"degree": 0, "strength": 0.0}
+            for node_id in selected_node_ids
+        }
+        for edge in edges:
+            source = edge["source"]
+            target = edge["target"]
+            weight = float(edge["weight"])
+            if source in metrics:
+                metrics[source]["degree"] = int(metrics[source]["degree"]) + 1
+                metrics[source]["strength"] = float(metrics[source]["strength"]) + weight
+            if target in metrics:
+                metrics[target]["degree"] = int(metrics[target]["degree"]) + 1
+                metrics[target]["strength"] = float(metrics[target]["strength"]) + weight
+        return metrics
 
     def _load_graph_tool(self) -> dict[str, Any]:
         try:

--- a/backend/tests/unit/test_coauthorship.py
+++ b/backend/tests/unit/test_coauthorship.py
@@ -295,6 +295,8 @@ def test_filter_subgraph_researcher_and_weight_limit() -> None:
     assert subgraph["summary"]["node_count"] == 2
     assert subgraph["summary"]["edge_count"] == 1
     assert {node["id"] for node in subgraph["nodes"]} == {center_id, neighbor_heavy_id}
+    assert subgraph["edges"][0]["shared_publication_count"] == 3
+    assert subgraph["edges"][0]["shared_publication_ids"] == []
 
 
 def test_filter_subgraph_prioritizes_attributed_nodes_when_max_nodes_is_applied() -> None:
@@ -374,6 +376,237 @@ def test_filter_subgraph_prioritizes_attributed_nodes_when_max_nodes_is_applied(
         "attributed-medium",
         "attributed-light",
     }
+
+
+def test_filter_subgraph_supports_largest_component_and_min_degree() -> None:
+    service = CoauthorshipGraphService(cast(Session, FakeSession([])), _settings())
+    payload = {
+        "build_id": str(uuid4()),
+        "graph_type": "coauthorship",
+        "generated_at": "2026-04-22T10:00:00+00:00",
+        "summary": {
+            "node_count": 5,
+            "edge_count": 3,
+            "component_count": 2,
+            "community_count": 1,
+            "graph_version": "abc123",
+        },
+        "data_snapshot": {},
+        "nodes": [
+            {
+                "id": "a",
+                "label": "A",
+                "full_name": "A",
+                "normalized_name": "a",
+                "primary_organization_id": None,
+                "primary_organization_name": None,
+                "degree": 2,
+                "strength": 4,
+                "betweenness": 0.0,
+                "component_id": 0,
+                "community_id": 0,
+            },
+            {
+                "id": "b",
+                "label": "B",
+                "full_name": "B",
+                "normalized_name": "b",
+                "primary_organization_id": None,
+                "primary_organization_name": None,
+                "degree": 2,
+                "strength": 4,
+                "betweenness": 0.0,
+                "component_id": 0,
+                "community_id": 0,
+            },
+            {
+                "id": "c",
+                "label": "C",
+                "full_name": "C",
+                "normalized_name": "c",
+                "primary_organization_id": None,
+                "primary_organization_name": None,
+                "degree": 2,
+                "strength": 4,
+                "betweenness": 0.0,
+                "component_id": 0,
+                "community_id": 0,
+            },
+            {
+                "id": "d",
+                "label": "D",
+                "full_name": "D",
+                "normalized_name": "d",
+                "primary_organization_id": None,
+                "primary_organization_name": None,
+                "degree": 1,
+                "strength": 1,
+                "betweenness": 0.0,
+                "component_id": 1,
+                "community_id": 0,
+            },
+            {
+                "id": "e",
+                "label": "E",
+                "full_name": "E",
+                "normalized_name": "e",
+                "primary_organization_id": None,
+                "primary_organization_name": None,
+                "degree": 1,
+                "strength": 1,
+                "betweenness": 0.0,
+                "component_id": 1,
+                "community_id": 0,
+            },
+        ],
+        "edges": [
+            {
+                "source": "a",
+                "target": "b",
+                "weight": 2,
+                "shared_publication_count": 2,
+                "first_collaboration_year": 2024,
+                "last_collaboration_year": 2025,
+                "shared_publication_ids": ["p1", "p2"],
+            },
+            {
+                "source": "b",
+                "target": "c",
+                "weight": 2,
+                "shared_publication_count": 2,
+                "first_collaboration_year": 2024,
+                "last_collaboration_year": 2025,
+                "shared_publication_ids": ["p3", "p4"],
+            },
+            {
+                "source": "d",
+                "target": "e",
+                "weight": 1,
+                "shared_publication_count": 1,
+                "first_collaboration_year": 2025,
+                "last_collaboration_year": 2025,
+                "shared_publication_ids": ["p5"],
+            },
+        ],
+    }
+
+    subgraph = service._filter_subgraph(
+        payload,
+        researcher_id=None,
+        organization_id=None,
+        max_nodes=None,
+        min_edge_weight=None,
+        min_degree=2,
+        largest_component_only=True,
+        community_id=None,
+    )
+
+    assert {node["id"] for node in subgraph["nodes"]} == {"b"}
+    assert subgraph["summary"]["node_count"] == 1
+    assert subgraph["summary"]["edge_count"] == 0
+    assert {node["id"]: node["degree"] for node in subgraph["nodes"]} == {
+        "b": 2,
+    }
+
+
+def test_filter_subgraph_largest_component_is_applied_after_max_nodes() -> None:
+    service = CoauthorshipGraphService(cast(Session, FakeSession([])), _settings())
+    payload = {
+        "build_id": str(uuid4()),
+        "graph_type": "coauthorship",
+        "generated_at": "2026-04-22T10:00:00+00:00",
+        "summary": {
+            "node_count": 6,
+            "edge_count": 5,
+            "component_count": 1,
+            "community_count": 1,
+            "graph_version": "abc123",
+        },
+        "data_snapshot": {},
+        "nodes": [
+            {
+                "id": node_id,
+                "label": node_id.upper(),
+                "full_name": node_id.upper(),
+                "normalized_name": node_id,
+                "primary_organization_id": None,
+                "primary_organization_name": None,
+                "degree": degree,
+                "strength": degree * 2,
+                "betweenness": 0.0,
+                "component_id": 0,
+                "community_id": 0,
+            }
+            for node_id, degree in [
+                ("a", 2),
+                ("b", 2),
+                ("c", 2),
+                ("d", 2),
+                ("e", 1),
+                ("f", 1),
+            ]
+        ],
+        "edges": [
+            {
+                "source": "a",
+                "target": "b",
+                "weight": 5,
+                "shared_publication_count": 5,
+                "first_collaboration_year": 2024,
+                "last_collaboration_year": 2025,
+                "shared_publication_ids": ["p1"],
+            },
+            {
+                "source": "b",
+                "target": "c",
+                "weight": 4,
+                "shared_publication_count": 4,
+                "first_collaboration_year": 2024,
+                "last_collaboration_year": 2025,
+                "shared_publication_ids": ["p2"],
+            },
+            {
+                "source": "c",
+                "target": "d",
+                "weight": 3,
+                "shared_publication_count": 3,
+                "first_collaboration_year": 2024,
+                "last_collaboration_year": 2025,
+                "shared_publication_ids": ["p3"],
+            },
+            {
+                "source": "d",
+                "target": "e",
+                "weight": 2,
+                "shared_publication_count": 2,
+                "first_collaboration_year": 2024,
+                "last_collaboration_year": 2025,
+                "shared_publication_ids": ["p4"],
+            },
+            {
+                "source": "e",
+                "target": "f",
+                "weight": 1,
+                "shared_publication_count": 1,
+                "first_collaboration_year": 2024,
+                "last_collaboration_year": 2025,
+                "shared_publication_ids": ["p5"],
+            },
+        ],
+    }
+
+    subgraph = service._filter_subgraph(
+        payload,
+        researcher_id=None,
+        organization_id=None,
+        max_nodes=4,
+        min_edge_weight=None,
+        min_degree=None,
+        largest_component_only=True,
+        community_id=None,
+    )
+
+    assert subgraph["summary"]["component_count"] == 1
 
 
 def test_compute_graph_version_is_stable_for_equivalent_inputs() -> None:

--- a/backend/tests/unit/test_openaire_seed.py
+++ b/backend/tests/unit/test_openaire_seed.py
@@ -52,6 +52,7 @@ class FakeSeedSession:
         self.rollback_calls = 0
         self.flush_calls = 0
         self.ingestion_runs: dict[UUID, IngestionRunModel] = {}
+        self.records_by_id: dict[UUID, object] = {}
         self.get_values = dict(get_values or {})
 
     def add(self, value: object) -> None:
@@ -63,6 +64,8 @@ class FakeSeedSession:
             object_id = getattr(value, "id", None)
             if object_id is None:
                 cast(Any, value).id = uuid4()
+                object_id = cast(UUID, cast(Any, value).id)
+            self.records_by_id[cast(UUID, object_id)] = value
             if isinstance(value, IngestionRunModel):
                 self.ingestion_runs[value.id] = value
 
@@ -83,10 +86,15 @@ class FakeSeedSession:
             return list(self.scalars_values.pop(0))
         return list(self.existing_relations)
 
-    def get(self, _model: type[object], key: UUID) -> IngestionRunModel | None:
+    def get(self, _model: type[object], key: UUID) -> object | None:
         if key in self.get_values:
-            return cast(IngestionRunModel | None, self.get_values[key])
+            return self.get_values[key]
+        if key in self.records_by_id:
+            return self.records_by_id[key]
         return self.ingestion_runs.get(key)
+
+    def expunge_all(self) -> None:
+        return None
 
 
 class FailingSeeder(OpenAireBeginnersKitSeeder):
@@ -123,7 +131,7 @@ def _settings() -> object:
         openaire_beginners_kit_path="data/openaire/beginners_kit",
         openaire_graph_api_base_url="https://api.openaire.eu/graph",
         openaire_graph_api_timeout_seconds=30,
-        openaire_graph_api_page_size=25,
+        openaire_graph_api_page_size=100,
         openaire_eunice_seed_max_publications=250,
     )
 
@@ -381,6 +389,10 @@ def test_eunice_seed_status_exposes_community_configuration() -> None:
     assert status_payload.api_base_url == "https://api.openaire.eu/graph"
     assert status_payload.community_id == "eunice"
     assert status_payload.product_type == "publication"
+    assert status_payload.publication_date_from == "2026-01-01"
+    assert status_payload.publication_date_to == "2026-12-31"
+    assert status_payload.pagination_mode == "cursor"
+    assert status_payload.page_size == 100
     assert status_payload.default_max_publications == 250
 
 
@@ -420,6 +432,57 @@ def test_graph_api_client_falls_back_from_beta_to_production_on_405(monkeypatch:
 
     assert payload == [{"id": "openorgs::1"}]
     assert client.active_base_url == "https://api.openaire.eu/graph"
+
+
+def test_graph_api_client_iterates_research_products_with_cursor(monkeypatch: Any) -> None:
+    client = OpenAireGraphApiClient(
+        base_url="https://api.openaire.eu/graph",
+        timeout_seconds=10,
+    )
+
+    responses = {
+        "cursor=%2A": (
+            b'{"header":{"numFound":3,"pageSize":2,"nextCursor":"cursor-2"},'
+            b'"results":[{"id":"pub-1"},{"id":"pub-2"}]}'
+        ),
+        "cursor=cursor-2": (
+            b'{"header":{"numFound":3,"pageSize":1},"results":[{"id":"pub-3"}]}'
+        ),
+    }
+
+    class _Response:
+        def __init__(self, payload: bytes) -> None:
+            self._payload = payload
+
+        def __enter__(self) -> _Response:
+            return self
+
+        def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return self._payload
+
+    def fake_urlopen(req: Any, timeout: int) -> _Response:
+        for marker, payload in responses.items():
+            if marker in req.full_url:
+                return _Response(payload)
+        raise AssertionError(f"Unexpected URL {req.full_url}")
+
+    monkeypatch.setattr(request, "urlopen", fake_urlopen)
+
+    pages = list(
+        client.iter_research_product_pages(
+            max_results=None,
+            page_size=2,
+            relCommunityId="eunice",
+            type="publication",
+            fromPublicationDate="2026-01-01",
+            toPublicationDate="2026-12-31",
+        )
+    )
+
+    assert [[item["id"] for item in page] for page in pages] == [["pub-1", "pub-2"], ["pub-3"]]
 
 
 def test_extract_publication_organizations_deduplicates_eunice_variants() -> None:
@@ -474,18 +537,19 @@ def test_materialize_candidate_affiliations_links_all_authors_when_single_org() 
     )
     session = FakeSeedSession(
         scalars_values=[[author_a, author_b], [], [], []],
-        get_values={publication.id: publication},
     )
     seeder = OpenAireGraphEuniceSeeder(cast(Session, session), cast(Any, _settings()))
     organization_id = uuid4()
-    seeder._affiliation_candidate_orgs_by_publication[publication.id] = {organization_id}
 
-    ambiguous = seeder._materialize_candidate_affiliations()
+    ambiguous = seeder._materialize_candidate_affiliations_for_publication(
+        publication=publication,
+        organization_ids={organization_id},
+    )
 
     affiliations = [
         item for item in session.added if isinstance(item, ResearcherAffiliationModel)
     ]
-    assert ambiguous == 0
+    assert ambiguous is False
     assert len(affiliations) == 2
     assert {affiliation.organization_id for affiliation in affiliations} == {organization_id}
 
@@ -497,13 +561,15 @@ def test_materialize_candidate_affiliations_skips_multi_org_publications() -> No
         normalized_title="collaborative publication",
         canonical_source_record_id=uuid4(),
     )
-    session = FakeSeedSession(get_values={publication.id: publication})
+    session = FakeSeedSession()
     seeder = OpenAireGraphEuniceSeeder(cast(Session, session), cast(Any, _settings()))
-    seeder._affiliation_candidate_orgs_by_publication[publication.id] = {uuid4(), uuid4()}
 
-    ambiguous = seeder._materialize_candidate_affiliations()
+    ambiguous = seeder._materialize_candidate_affiliations_for_publication(
+        publication=publication,
+        organization_ids={uuid4(), uuid4()},
+    )
 
-    assert ambiguous == 1
+    assert ambiguous is True
     assert not [
         item for item in session.added if isinstance(item, ResearcherAffiliationModel)
     ]

--- a/backend/tests/unit/test_semantic_graph.py
+++ b/backend/tests/unit/test_semantic_graph.py
@@ -6,8 +6,12 @@ from types import SimpleNamespace
 from typing import Any, cast
 from uuid import UUID, uuid4
 
+from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from eunigraph.api.deps import get_db_session
+from eunigraph.api.routers import semantic_graph as semantic_graph_router
+from eunigraph.main import app
 from eunigraph.modules.catalog.infrastructure.models import (
     OrganizationModel,
     PublicationAuthorModel,
@@ -379,6 +383,346 @@ def test_filter_subgraph_by_publication_and_organization() -> None:
     assert subgraph["summary"]["node_count"] == 2
     assert subgraph["summary"]["edge_count"] == 1
     assert {node["id"] for node in subgraph["nodes"]} == {publication_id, related_id}
+
+
+def test_filter_subgraph_supports_largest_component_and_min_degree() -> None:
+    service = SemanticGraphService(cast(Session, FakeSession([])), _settings())
+    payload = {
+        "build_id": str(uuid4()),
+        "graph_type": "semantic_similarity",
+        "generated_at": "2026-04-22T12:00:00+00:00",
+        "summary": {
+            "node_count": 5,
+            "edge_count": 3,
+            "component_count": 2,
+            "community_count": 1,
+            "graph_version": "abc123",
+        },
+        "data_snapshot": {},
+        "nodes": [
+            {
+                "id": "p1",
+                "label": "P1",
+                "title": "P1",
+                "normalized_title": "p1",
+                "publication_year": 2026,
+                "doi": None,
+                "openaire_id": None,
+                "publication_type": None,
+                "language_code": None,
+                "journal_name": None,
+                "venue_name": None,
+                "authors": [],
+                "organization_ids": [],
+                "organization_names": [],
+                "degree": 1,
+                "strength": 0.9,
+                "betweenness": 0.0,
+                "component_id": 0,
+                "community_id": 0,
+            },
+            {
+                "id": "p2",
+                "label": "P2",
+                "title": "P2",
+                "normalized_title": "p2",
+                "publication_year": 2026,
+                "doi": None,
+                "openaire_id": None,
+                "publication_type": None,
+                "language_code": None,
+                "journal_name": None,
+                "venue_name": None,
+                "authors": [],
+                "organization_ids": [],
+                "organization_names": [],
+                "degree": 2,
+                "strength": 1.8,
+                "betweenness": 0.0,
+                "component_id": 0,
+                "community_id": 0,
+            },
+            {
+                "id": "p3",
+                "label": "P3",
+                "title": "P3",
+                "normalized_title": "p3",
+                "publication_year": 2026,
+                "doi": None,
+                "openaire_id": None,
+                "publication_type": None,
+                "language_code": None,
+                "journal_name": None,
+                "venue_name": None,
+                "authors": [],
+                "organization_ids": [],
+                "organization_names": [],
+                "degree": 1,
+                "strength": 0.9,
+                "betweenness": 0.0,
+                "component_id": 0,
+                "community_id": 0,
+            },
+            {
+                "id": "p4",
+                "label": "P4",
+                "title": "P4",
+                "normalized_title": "p4",
+                "publication_year": 2026,
+                "doi": None,
+                "openaire_id": None,
+                "publication_type": None,
+                "language_code": None,
+                "journal_name": None,
+                "venue_name": None,
+                "authors": [],
+                "organization_ids": [],
+                "organization_names": [],
+                "degree": 1,
+                "strength": 0.6,
+                "betweenness": 0.0,
+                "component_id": 1,
+                "community_id": 0,
+            },
+            {
+                "id": "p5",
+                "label": "P5",
+                "title": "P5",
+                "normalized_title": "p5",
+                "publication_year": 2026,
+                "doi": None,
+                "openaire_id": None,
+                "publication_type": None,
+                "language_code": None,
+                "journal_name": None,
+                "venue_name": None,
+                "authors": [],
+                "organization_ids": [],
+                "organization_names": [],
+                "degree": 1,
+                "strength": 0.6,
+                "betweenness": 0.0,
+                "component_id": 1,
+                "community_id": 0,
+            },
+        ],
+        "edges": [
+            {
+                "source": "p1",
+                "target": "p2",
+                "weight": 0.9,
+                "similarity_score": 0.9,
+                "rank": 1,
+                "mutual_match": True,
+                "source_rank": 1,
+                "target_rank": 1,
+                "source_score": 0.9,
+                "target_score": 0.9,
+            },
+            {
+                "source": "p2",
+                "target": "p3",
+                "weight": 0.9,
+                "similarity_score": 0.9,
+                "rank": 1,
+                "mutual_match": True,
+                "source_rank": 1,
+                "target_rank": 1,
+                "source_score": 0.9,
+                "target_score": 0.9,
+            },
+            {
+                "source": "p4",
+                "target": "p5",
+                "weight": 0.6,
+                "similarity_score": 0.6,
+                "rank": 1,
+                "mutual_match": True,
+                "source_rank": 1,
+                "target_rank": 1,
+                "source_score": 0.6,
+                "target_score": 0.6,
+            },
+        ],
+    }
+
+    subgraph = service._filter_subgraph(
+        payload,
+        publication_id=None,
+        organization_id=None,
+        publication_year=None,
+        max_nodes=None,
+        min_edge_weight=None,
+        min_degree=2,
+        largest_component_only=True,
+        community_id=None,
+    )
+
+    assert {node["id"] for node in subgraph["nodes"]} == {"p2"}
+    assert subgraph["summary"]["node_count"] == 1
+    assert subgraph["summary"]["edge_count"] == 0
+    assert {node["id"]: node["degree"] for node in subgraph["nodes"]} == {
+        "p2": 2,
+    }
+
+
+def test_filter_subgraph_largest_component_is_applied_after_max_nodes() -> None:
+    service = SemanticGraphService(cast(Session, FakeSession([])), _settings())
+    payload = {
+        "build_id": str(uuid4()),
+        "graph_type": "semantic_similarity",
+        "generated_at": "2026-04-22T12:00:00+00:00",
+        "summary": {
+            "node_count": 6,
+            "edge_count": 5,
+            "component_count": 1,
+            "community_count": 1,
+            "graph_version": "abc123",
+        },
+        "data_snapshot": {},
+        "nodes": [
+            {
+                "id": node_id,
+                "label": node_id.upper(),
+                "title": node_id.upper(),
+                "normalized_title": node_id,
+                "publication_year": 2026,
+                "doi": None,
+                "openaire_id": None,
+                "publication_type": None,
+                "language_code": None,
+                "journal_name": None,
+                "venue_name": None,
+                "authors": [],
+                "organization_ids": [],
+                "organization_names": [],
+                "degree": degree,
+                "strength": float(degree),
+                "betweenness": 0.0,
+                "component_id": 0,
+                "community_id": 0,
+            }
+            for node_id, degree in [
+                ("p1", 2),
+                ("p2", 2),
+                ("p3", 2),
+                ("p4", 2),
+                ("p5", 1),
+                ("p6", 1),
+            ]
+        ],
+        "edges": [
+            {
+                "source": "p1",
+                "target": "p2",
+                "weight": 0.95,
+                "similarity_score": 0.95,
+                "rank": 1,
+                "mutual_match": True,
+                "source_rank": 1,
+                "target_rank": 1,
+                "source_score": 0.95,
+                "target_score": 0.95,
+            },
+            {
+                "source": "p2",
+                "target": "p3",
+                "weight": 0.9,
+                "similarity_score": 0.9,
+                "rank": 1,
+                "mutual_match": True,
+                "source_rank": 1,
+                "target_rank": 1,
+                "source_score": 0.9,
+                "target_score": 0.9,
+            },
+            {
+                "source": "p3",
+                "target": "p4",
+                "weight": 0.85,
+                "similarity_score": 0.85,
+                "rank": 1,
+                "mutual_match": True,
+                "source_rank": 1,
+                "target_rank": 1,
+                "source_score": 0.85,
+                "target_score": 0.85,
+            },
+            {
+                "source": "p4",
+                "target": "p5",
+                "weight": 0.8,
+                "similarity_score": 0.8,
+                "rank": 1,
+                "mutual_match": True,
+                "source_rank": 1,
+                "target_rank": 1,
+                "source_score": 0.8,
+                "target_score": 0.8,
+            },
+            {
+                "source": "p5",
+                "target": "p6",
+                "weight": 0.75,
+                "similarity_score": 0.75,
+                "rank": 1,
+                "mutual_match": True,
+                "source_rank": 1,
+                "target_rank": 1,
+                "source_score": 0.75,
+                "target_score": 0.75,
+            },
+        ],
+    }
+
+    subgraph = service._filter_subgraph(
+        payload,
+        publication_id=None,
+        organization_id=None,
+        publication_year=None,
+        max_nodes=4,
+        min_edge_weight=None,
+        min_degree=None,
+        largest_component_only=True,
+        community_id=None,
+    )
+
+    assert subgraph["summary"]["component_count"] == 1
+
+
+def test_semantic_subgraph_accepts_more_than_2500_nodes(monkeypatch: Any) -> None:
+    class StubService:
+        def get_subgraph(self, **_: object) -> dict[str, object]:
+            return {
+                "build_id": str(uuid4()),
+                "graph_type": "semantic_similarity",
+                "generated_at": "2026-04-22T12:00:00Z",
+                "summary": {
+                    "node_count": 0,
+                    "edge_count": 0,
+                    "component_count": 0,
+                    "community_count": None,
+                    "graph_version": "test-version",
+                },
+                "nodes": [],
+                "edges": [],
+                "data_snapshot": {},
+            }
+
+    def override_db_session() -> object:
+        return object()
+
+    app.dependency_overrides[get_db_session] = override_db_session
+    monkeypatch.setattr(semantic_graph_router, "_service", lambda *_: StubService())
+
+    try:
+        client = TestClient(app)
+        response = client.get("/api/v1/semantic-graph/subgraph?max_nodes=5000")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.json()["summary"]["node_count"] == 0
 
 
 def test_render_svg_for_graph_uses_scatter_layout_without_labels() -> None:

--- a/docs/backend-overview.md
+++ b/docs/backend-overview.md
@@ -131,7 +131,7 @@ The backend currently follows these important choices:
 - canonical relational model in PostgreSQL, not direct exposure of raw OpenAIRE payloads
 - strong provenance via `source_record`
 - two distinct seed paths for MVP/demo data:
-  - community-scoped EUNICE seed via the OpenAIRE Graph API v2 as the main demo workflow
+  - community-scoped EUNICE seed via the OpenAIRE Graph API v2 as the main demo workflow, currently constrained to 2026 publications
   - local OpenAIRE Beginner's Kit archives as a secondary archive-based path
 - provider-based embeddings abstraction
 - materialized graph pipelines rather than live rebuilds on every request

--- a/docs/frontend-admin-console.md
+++ b/docs/frontend-admin-console.md
@@ -129,8 +129,10 @@ For the EUNICE seed, the operations view exposes:
 - the Graph API base URL
 - the fixed OpenAIRE community scope `eunice`
 - the fixed product type `publication`
+- the fixed demo date window `2026-01-01 -> 2026-12-31`
+- the pagination strategy (`cursor`)
+- the effective API page size
 - an optional overall publication cap
-- an optional publication year range
 
 The response preview intentionally exposes processed publication counts, new canonical rows and ambiguous-publication counts so the operator can understand how much of the demo dataset was actually materialized.
 

--- a/docs/frontend-graph-explorer.md
+++ b/docs/frontend-graph-explorer.md
@@ -70,6 +70,8 @@ The explorer only exposes filters already supported by the backend.
 - `organization_id`
 - `max_nodes`
 - `min_edge_weight`
+- `min_degree`
+- `largest_component_only`
 - `community_id`
 
 ### Semantic filters
@@ -78,6 +80,8 @@ The explorer only exposes filters already supported by the backend.
 - `publication_year`
 - `max_nodes`
 - `min_edge_weight`
+- `min_degree`
+- `largest_component_only`
 - `community_id`
 
 The explorer initializes with `max_nodes=250`, so the default experience loads a backend subgraph instead of the full persisted graph payload.
@@ -85,6 +89,10 @@ The explorer initializes with `max_nodes=250`, so the default experience loads a
 If the operator clears `max_nodes` and other filters, the explorer can still load the full persisted graph payload.
 
 When a filter is active, the explorer always loads a backend subgraph instead of pruning locally.
+
+The frontend keeps the existing visual design, but the rendering path has been hardened for larger graph slices:
+- Cytoscape is updated in place when filters change instead of being torn down and recreated for every payload refresh
+- filter application is deferred through React transitions to keep the controls responsive while larger subgraphs are loading
 
 ## 7. Detail Panels
 
@@ -146,6 +154,5 @@ The UX is shared, but the node and edge semantics differ:
 - coauthorship coloring is intentionally limited to a governed EUNICE university set
 - ambiguous multi-university cases remain neutral instead of being forced into one institutional color
 - the first-load default uses `max_nodes=250` to avoid throwing the full graph at the browser
-- the coauthorship subgraph API still enforces a bounded `max_nodes` request rather than allowing unbounded oversized payloads
 
 The explorer is intentionally focused on reliable retrieval and readable exploration of the materialized backend graphs.

--- a/docs/seed-and-api.md
+++ b/docs/seed-and-api.md
@@ -19,6 +19,8 @@ The workflow uses the OpenAIRE Graph API v2 and fetches only research products f
 
 - `relCommunityId=eunice`
 - `type=publication`
+- `fromPublicationDate=2026-01-01`
+- `toPublicationDate=2026-12-31`
 
 The current implementation intentionally stays publication-centered because the canonical model, browsing UI and graph layers are all publication-first.
 
@@ -26,7 +28,7 @@ The current implementation intentionally stays publication-centered because the 
 
 The EUNICE seed imports only data relevant to the OpenAIRE community slice for `eunice`:
 
-- `publication` rows returned by `GET /graph/v2/researchProducts?relCommunityId=eunice&type=publication`
+- `publication` rows returned by `GET /graph/v2/researchProducts?relCommunityId=eunice&type=publication&fromPublicationDate=2026-01-01&toPublicationDate=2026-12-31`
 - `organization` rows embedded in publication metadata
 - `researcher` rows derived from publication author metadata
 - `publication_author`
@@ -45,10 +47,30 @@ Confirmed source-of-truth syntax for the current workflow:
   - `GET https://api.openaire.eu/graph/v2/researchProducts?relCommunityId=eunice`
 - publications only:
   - `GET https://api.openaire.eu/graph/v2/researchProducts?relCommunityId=eunice&type=publication`
+- publications only, constrained to the current demo year:
+  - `GET https://api.openaire.eu/graph/v2/researchProducts?relCommunityId=eunice&type=publication&fromPublicationDate=2026-01-01&toPublicationDate=2026-12-31`
 
-The implemented seed uses the publication-only variant.
+The implemented seed uses the publication-only 2026-constrained variant because it produces a smaller and more coherent demo slice.
 
 OpenAIRE Graph documentation also states that `v2/researchProducts` responses contain `organizations` and `communities`, which is what the current mapping relies on.
+
+## EUNICE Pagination And Robustness
+
+The current EUNICE seed uses:
+
+- `pageSize` clamped to the OpenAIRE-supported range `1..100`
+- cursor pagination first, starting from `cursor=*`
+- fallback to page-based pagination only if the response does not expose `header.nextCursor`
+- one persistence commit per fetched API page
+
+The backend no longer accumulates the full remote result set in memory before persisting it.
+
+This change was introduced because the previous implementation:
+
+- collected all `researchProducts` in a Python list before writing them
+- kept a long-lived SQLAlchemy session with growing ORM state and raw provenance payloads
+
+That combination was the main cause of the backend becoming fragile once the load moved beyond roughly 1000 publications.
 
 ## EUNICE Affiliation Rule
 

--- a/frontend/app/api/backend/[...path]/route.ts
+++ b/frontend/app/api/backend/[...path]/route.ts
@@ -1,9 +1,52 @@
+import { request as httpRequest } from "node:http";
+import type { IncomingMessage, RequestOptions } from "node:http";
+import { request as httpsRequest } from "node:https";
+import { Readable } from "node:stream";
+
 import { NextRequest } from "next/server";
 
 import { getBackendBaseUrl } from "@/lib/config";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
+export const maxDuration = 300;
+
+const UPSTREAM_TIMEOUT_MS = 300_000;
+
+function proxyUpstreamRequest(
+  upstreamUrl: URL,
+  request: NextRequest,
+  headers: Headers,
+  body: ArrayBuffer | undefined,
+): Promise<IncomingMessage> {
+  const requestImpl = upstreamUrl.protocol === "https:" ? httpsRequest : httpRequest;
+  const requestOptions: RequestOptions = {
+    protocol: upstreamUrl.protocol,
+    hostname: upstreamUrl.hostname,
+    port: upstreamUrl.port ? Number(upstreamUrl.port) : undefined,
+    path: `${upstreamUrl.pathname}${upstreamUrl.search}`,
+    method: request.method,
+    headers: Object.fromEntries(headers.entries()),
+  };
+
+  return new Promise((resolve, reject) => {
+    const upstreamRequest = requestImpl(requestOptions, (upstreamResponse) => {
+      resolve(upstreamResponse);
+    });
+
+    upstreamRequest.setTimeout(UPSTREAM_TIMEOUT_MS, () => {
+      upstreamRequest.destroy(
+        new Error(`Upstream backend request timed out after ${UPSTREAM_TIMEOUT_MS}ms.`),
+      );
+    });
+    upstreamRequest.on("error", reject);
+
+    if (body && body.byteLength > 0) {
+      upstreamRequest.write(Buffer.from(body));
+    }
+    upstreamRequest.end();
+  });
+}
 
 async function proxyRequest(request: NextRequest): Promise<Response> {
   const incomingUrl = new URL(request.url);
@@ -25,19 +68,26 @@ async function proxyRequest(request: NextRequest): Promise<Response> {
       ? undefined
       : await request.arrayBuffer();
 
-  const upstreamResponse = await fetch(upstreamUrl, {
-    method: request.method,
-    headers,
-    body,
-    cache: "no-store",
-  });
+  const upstreamResponse = await proxyUpstreamRequest(upstreamUrl, request, headers, body);
 
-  const responseHeaders = new Headers(upstreamResponse.headers);
+  const responseHeaders = new Headers();
+  for (const [key, value] of Object.entries(upstreamResponse.headers)) {
+    if (value === undefined) {
+      continue;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        responseHeaders.append(key, item);
+      }
+      continue;
+    }
+    responseHeaders.set(key, value);
+  }
   responseHeaders.delete("content-encoding");
   responseHeaders.delete("transfer-encoding");
 
-  return new Response(upstreamResponse.body, {
-    status: upstreamResponse.status,
+  return new Response(Readable.toWeb(upstreamResponse) as ReadableStream, {
+    status: upstreamResponse.statusCode ?? 502,
     headers: responseHeaders,
   });
 }

--- a/frontend/src/components/admin/operations-console.tsx
+++ b/frontend/src/components/admin/operations-console.tsx
@@ -43,8 +43,6 @@ type SeedLoadForm = {
 
 type EUNICESeedForm = {
   max_publications: string;
-  publication_year_from: string;
-  publication_year_to: string;
 };
 
 type NormalizationForm = {
@@ -315,8 +313,6 @@ function EUNICESeedOperations() {
   const { handleSubmit, register } = useForm<EUNICESeedForm>({
     defaultValues: {
       max_publications: "250",
-      publication_year_from: "",
-      publication_year_to: "",
     },
   });
 
@@ -335,6 +331,11 @@ function EUNICESeedOperations() {
                 { label: "Community", value: status.data.community_id },
                 { label: "Product", value: status.data.product_type },
                 {
+                  label: "Date window",
+                  value: `${status.data.publication_date_from} -> ${status.data.publication_date_to}`,
+                },
+                { label: "Paging", value: `${status.data.pagination_mode} / ${status.data.page_size}` },
+                {
                   label: "Latest run",
                   value: status.data.latest_ingestion_status ?? "Not available",
                 },
@@ -349,7 +350,11 @@ function EUNICESeedOperations() {
                 <code className="mx-1 rounded bg-zinc-100 px-1.5 py-0.5 text-xs text-zinc-700">
                   relCommunityId=eunice
                 </code>
-                and imports only publications plus embedded authors and organizations.
+                ,
+                <code className="mx-1 rounded bg-zinc-100 px-1.5 py-0.5 text-xs text-zinc-700">
+                  type=publication
+                </code>
+                and the fixed 2026 date window. It imports publications plus embedded authors and organizations.
               </p>
             </div>
           </div>
@@ -359,31 +364,20 @@ function EUNICESeedOperations() {
           onSubmit={handleSubmit((values) =>
             mutation.mutate({
               max_publications: optionalNumber(values.max_publications),
-              publication_year_from: optionalNumber(values.publication_year_from),
-              publication_year_to: optionalNumber(values.publication_year_to),
             }),
           )}
           className="space-y-3"
         >
-          <div className="grid gap-3 md:grid-cols-3">
+          <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto]">
             <input
               {...register("max_publications")}
               className={inputClass}
               inputMode="numeric"
               placeholder="Max publications"
             />
-            <input
-              {...register("publication_year_from")}
-              className={inputClass}
-              inputMode="numeric"
-              placeholder="Optional year from"
-            />
-            <input
-              {...register("publication_year_to")}
-              className={inputClass}
-              inputMode="numeric"
-              placeholder="Optional year to"
-            />
+            <div className="rounded-[1rem] border border-[color:var(--border)] bg-zinc-50 px-4 py-3 text-sm text-zinc-600">
+              2026 only
+            </div>
           </div>
           <button type="submit" disabled={mutation.isPending} className={buttonClass}>
             Load EUNICE seed

--- a/frontend/src/components/graphs/graph-controls.tsx
+++ b/frontend/src/components/graphs/graph-controls.tsx
@@ -8,6 +8,8 @@ type CoauthorshipControlState = {
   communityId: string;
   maxNodes: string;
   minEdgeWeight: string;
+  minDegree: string;
+  largestComponentOnly: boolean;
 };
 
 type SemanticControlState = {
@@ -17,6 +19,8 @@ type SemanticControlState = {
   communityId: string;
   maxNodes: string;
   minEdgeWeight: string;
+  minDegree: string;
+  largestComponentOnly: boolean;
 };
 
 type GraphControlsProps = {
@@ -24,8 +28,11 @@ type GraphControlsProps = {
   onLayerChange: (layer: GraphLayer) => void;
   coauthorship: CoauthorshipControlState;
   semantic: SemanticControlState;
-  onCoauthorshipChange: (key: keyof CoauthorshipControlState, value: string) => void;
-  onSemanticChange: (key: keyof SemanticControlState, value: string) => void;
+  onCoauthorshipChange: (
+    key: keyof CoauthorshipControlState,
+    value: string | boolean,
+  ) => void;
+  onSemanticChange: (key: keyof SemanticControlState, value: string | boolean) => void;
   onApply: () => void;
   onResetFilters: () => void;
   onResetView: () => void;
@@ -150,12 +157,39 @@ export function GraphControls({
           placeholder={layer === "coauthorship" ? "Min edge weight" : "Min similarity weight"}
           className="rounded-[1rem] border border-[color:var(--border)] bg-white px-4 py-3 text-sm outline-none focus:border-zinc-900"
         />
+        <input
+          value={layer === "coauthorship" ? coauthorship.minDegree : semantic.minDegree}
+          onChange={(event) =>
+            layer === "coauthorship"
+              ? onCoauthorshipChange("minDegree", event.target.value)
+              : onSemanticChange("minDegree", event.target.value)
+          }
+          placeholder="Min degree"
+          className="rounded-[1rem] border border-[color:var(--border)] bg-white px-4 py-3 text-sm outline-none focus:border-zinc-900"
+        />
         <div className="rounded-[1rem] border border-dashed border-zinc-200 bg-white px-4 py-3 text-sm leading-6 text-zinc-500">
           {layer === "coauthorship"
             ? "Researchers linked by shared publications."
             : "Publications linked by semantic score."}
         </div>
       </div>
+
+      <label className="inline-flex items-center gap-3 rounded-full border border-[color:var(--border)] bg-white px-4 py-2 text-sm text-zinc-700">
+        <input
+          type="checkbox"
+          checked={
+            layer === "coauthorship"
+              ? coauthorship.largestComponentOnly
+              : semantic.largestComponentOnly
+          }
+          onChange={(event) =>
+            layer === "coauthorship"
+              ? onCoauthorshipChange("largestComponentOnly", event.target.checked)
+              : onSemanticChange("largestComponentOnly", event.target.checked)
+          }
+        />
+        Largest connected component
+      </label>
 
       <div className="flex flex-wrap gap-3">
         <button

--- a/frontend/src/components/graphs/unified-graph-explorer.tsx
+++ b/frontend/src/components/graphs/unified-graph-explorer.tsx
@@ -1,7 +1,13 @@
 "use client";
 
-import type { Core, ElementDefinition, EventObject, NodeSingular, EdgeSingular } from "cytoscape";
-import { useEffect, useMemo, useRef, useState } from "react";
+import type {
+  Core,
+  ElementDefinition,
+  EventObject,
+  NodeSingular,
+  EdgeSingular,
+} from "cytoscape";
+import { useDeferredValue, useEffect, useMemo, useRef, useState, useTransition } from "react";
 
 import { EmptyState } from "@/components/states/empty-state";
 import { ErrorState } from "@/components/states/error-state";
@@ -44,6 +50,8 @@ type CoauthorshipControlState = {
   communityId: string;
   maxNodes: string;
   minEdgeWeight: string;
+  minDegree: string;
+  largestComponentOnly: boolean;
 };
 
 type SemanticControlState = {
@@ -53,6 +61,8 @@ type SemanticControlState = {
   communityId: string;
   maxNodes: string;
   minEdgeWeight: string;
+  minDegree: string;
+  largestComponentOnly: boolean;
 };
 
 function toOptionalNumber(value: string): number | undefined {
@@ -72,6 +82,8 @@ function normalizeCoauthorshipFilters(
     community_id: toOptionalNumber(state.communityId),
     max_nodes: toOptionalNumber(state.maxNodes),
     min_edge_weight: toOptionalNumber(state.minEdgeWeight),
+    min_degree: toOptionalNumber(state.minDegree),
+    largest_component_only: state.largestComponentOnly || undefined,
   };
 }
 
@@ -83,11 +95,17 @@ function normalizeSemanticFilters(state: SemanticControlState): SemanticSubgraph
     community_id: toOptionalNumber(state.communityId),
     max_nodes: toOptionalNumber(state.maxNodes),
     min_edge_weight: toOptionalNumber(state.minEdgeWeight),
+    min_degree: toOptionalNumber(state.minDegree),
+    largest_component_only: state.largestComponentOnly || undefined,
   };
 }
 
 function hasAnyValue(values: Record<string, string>): boolean {
   return Object.values(values).some((value) => value.trim().length > 0);
+}
+
+function hasAnyToggle(values: { largestComponentOnly: boolean }): boolean {
+  return values.largestComponentOnly;
 }
 
 type CoauthorshipOrganizationLegendItem = {
@@ -99,6 +117,7 @@ type CoauthorshipOrganizationLegendItem = {
 };
 
 const DEFAULT_GRAPH_NODE_LIMIT = 250;
+const LARGE_GRAPH_NODE_THRESHOLD = 1500;
 
 function defaultNodeLimitValue(): string {
   return String(DEFAULT_GRAPH_NODE_LIMIT);
@@ -128,6 +147,8 @@ export function UnifiedGraphExplorer({
   initialLayer = "coauthorship",
 }: UnifiedGraphExplorerProps) {
   const [layer, setLayer] = useState<GraphLayer>(initialLayer);
+  const [isApplyingFilters, startGraphTransition] = useTransition();
+  const [isCanvasRendering, setIsCanvasRendering] = useState(false);
 
   const [coauthorshipDraft, setCoauthorshipDraft] = useState<CoauthorshipControlState>({
     researcherId: "",
@@ -135,6 +156,8 @@ export function UnifiedGraphExplorer({
     communityId: "",
     maxNodes: defaultNodeLimitValue(),
     minEdgeWeight: "",
+    minDegree: "",
+    largestComponentOnly: false,
   });
   const [semanticDraft, setSemanticDraft] = useState<SemanticControlState>({
     publicationId: "",
@@ -143,6 +166,8 @@ export function UnifiedGraphExplorer({
     communityId: "",
     maxNodes: defaultNodeLimitValue(),
     minEdgeWeight: "",
+    minDegree: "",
+    largestComponentOnly: false,
   });
 
   const [coauthorshipFilters, setCoauthorshipFilters] = useState<CoauthorshipSubgraphFilters>({
@@ -177,6 +202,9 @@ export function UnifiedGraphExplorer({
   const activeStatus = layer === "coauthorship" ? coauthorshipStatus : semanticStatus;
   const activeGraph = layer === "coauthorship" ? coauthorshipGraph : semanticGraph;
   const activeMetrics = layer === "coauthorship" ? coauthorshipMetrics : semanticMetrics;
+  const activeNodeCount = activeGraph.data?.nodes.length ?? 0;
+  const activeEdgeCount = activeGraph.data?.edges.length ?? 0;
+  const isLargeGraph = activeNodeCount >= LARGE_GRAPH_NODE_THRESHOLD;
 
   const elements = useMemo<ElementDefinition[]>(() => {
     if (!activeGraph.data) {
@@ -187,6 +215,7 @@ export function UnifiedGraphExplorer({
       ? mapCoauthorshipElements(activeGraph.data.nodes as CoauthorshipNode[], activeGraph.data.edges as CoauthorshipEdge[])
       : mapSemanticElements(activeGraph.data.nodes as SemanticNode[], activeGraph.data.edges as SemanticEdge[]);
   }, [activeGraph.data, layer]);
+  const deferredElements = useDeferredValue(elements);
 
   const nodeMap = useMemo(() => {
     if (!activeGraph.data) {
@@ -259,14 +288,91 @@ export function UnifiedGraphExplorer({
     );
   }, [coauthorshipGraph.data, layer]);
 
+  const layoutConfig = useMemo(
+    () => ({
+      name: "cose",
+      animate: false,
+      fit: true,
+      padding: 36,
+      nodeRepulsion: isLargeGraph ? 4200 : 8000,
+      idealEdgeLength: layer === "coauthorship" ? 80 : 110,
+      refresh: isLargeGraph ? 12 : 20,
+      randomize: true,
+      componentSpacing: isLargeGraph ? 48 : 80,
+      gravity: isLargeGraph ? 0.7 : 0.4,
+      numIter: isLargeGraph ? 220 : 700,
+      initialTemp: isLargeGraph ? 80 : 160,
+      coolingFactor: isLargeGraph ? 0.97 : 0.95,
+      minTemp: 1,
+    }),
+    [isLargeGraph, layer],
+  );
+
+  const cytoscapeStyle = useMemo(
+    () => [
+      {
+        selector: "node",
+        style: {
+          width: "data(size)",
+          height: "data(size)",
+          label: "",
+          "background-color": "data(nodeColor)",
+          "border-color": "#ffffff",
+          "border-width": 2,
+          opacity: 0.9,
+        },
+      },
+      {
+        selector: "node:selected",
+        style: {
+          label: "data(label)",
+          "text-wrap": "wrap" as const,
+          "text-max-width": "160px",
+          "font-size": "12px",
+          color: "#18181b",
+          "text-background-color": "#ffffff",
+          "text-background-opacity": 0.95,
+          "text-background-padding": "6px",
+          "text-background-shape": "roundrectangle",
+          "text-margin-y": -22,
+          "border-color": "#18181b",
+          "border-width": 3,
+        },
+      },
+      {
+        selector: "edge",
+        style: {
+          width: "data(lineWidth)",
+          "line-color":
+            layer === "coauthorship"
+              ? "rgba(24, 24, 27, 0.22)"
+              : "rgba(245, 158, 11, 0.35)",
+          "curve-style": "bezier" as const,
+          opacity: 0.72,
+        },
+      },
+      {
+        selector: "edge:selected",
+        style: {
+          width: "mapData(lineWidth, 1, 8, 3, 10)",
+          "line-color": "#18181b",
+          opacity: 1,
+        },
+      },
+    ],
+    [layer],
+  );
+
   useEffect(() => {
     let active = true;
+    let renderFallbackTimeout: ReturnType<typeof setTimeout> | null = null;
+    let layoutFrameId: number | null = null;
 
     async function mountGraph() {
       if (!canvasRef.current) {
         return;
       }
-
+      setIsCanvasRendering(true);
       const cytoscape = (await import("cytoscape")).default;
       if (!active || !canvasRef.current) {
         return;
@@ -275,68 +381,35 @@ export function UnifiedGraphExplorer({
       cyRef.current?.destroy();
       cyRef.current = cytoscape({
         container: canvasRef.current,
-        elements,
-        layout: {
-          name: "cose",
-          animate: false,
-          fit: true,
-          padding: 36,
-          nodeRepulsion: 8000,
-          idealEdgeLength: layer === "coauthorship" ? 80 : 110,
-        },
-        style: [
-          {
-            selector: "node",
-            style: {
-              width: "data(size)",
-              height: "data(size)",
-              label: "",
-              "background-color": "data(nodeColor)",
-              "border-color": "#ffffff",
-              "border-width": 2,
-              opacity: 0.9,
-            },
-          },
-          {
-            selector: "node:selected",
-            style: {
-              label: "data(label)",
-              "text-wrap": "wrap",
-              "text-max-width": "160px",
-              "font-size": "12px",
-              color: "#18181b",
-              "text-background-color": "#ffffff",
-              "text-background-opacity": 0.95,
-              "text-background-padding": "6px",
-              "text-background-shape": "roundrectangle",
-              "text-margin-y": -22,
-              "border-color": "#18181b",
-              "border-width": 3,
-            },
-          },
-          {
-            selector: "edge",
-            style: {
-              width: "data(lineWidth)",
-              "line-color":
-                layer === "coauthorship"
-                  ? "rgba(24, 24, 27, 0.22)"
-                  : "rgba(245, 158, 11, 0.35)",
-              "curve-style": "bezier",
-              opacity: 0.72,
-            },
-          },
-          {
-            selector: "edge:selected",
-            style: {
-              width: "mapData(lineWidth, 1, 8, 3, 10)",
-              "line-color": "#18181b",
-              opacity: 1,
-            },
-          },
-        ],
+        elements: deferredElements,
+        style: cytoscapeStyle as any,
         wheelSensitivity: 0.18,
+        pixelRatio: 1,
+        textureOnViewport: isLargeGraph,
+        hideEdgesOnViewport: isLargeGraph,
+        motionBlur: false,
       });
+
+      const finishCanvasRendering = () => {
+        if (active) {
+          setIsCanvasRendering(false);
+        }
+      };
+
+      cyRef.current.one("render", finishCanvasRendering);
+
+      const layout = cyRef.current.layout(layoutConfig);
+      layout.one("layoutstop", finishCanvasRendering);
+      layoutFrameId = requestAnimationFrame(() => {
+        if (active) {
+          layout.run();
+        }
+      });
+
+      renderFallbackTimeout = setTimeout(
+        finishCanvasRendering,
+        isLargeGraph ? 2200 : 1200,
+      );
 
       cyRef.current.on("tap", "node", (event: EventObject) => {
         const target = event.target as NodeSingular;
@@ -362,10 +435,17 @@ export function UnifiedGraphExplorer({
 
     return () => {
       active = false;
+      if (renderFallbackTimeout) {
+        clearTimeout(renderFallbackTimeout);
+      }
+      if (layoutFrameId !== null) {
+        cancelAnimationFrame(layoutFrameId);
+      }
+      setIsCanvasRendering(false);
       cyRef.current?.destroy();
       cyRef.current = null;
     };
-  }, [elements, layer]);
+  }, [deferredElements, cytoscapeStyle, isLargeGraph, layoutConfig, layer]);
 
   function handleLayerChange(nextLayer: GraphLayer) {
     setLayer(nextLayer);
@@ -375,10 +455,14 @@ export function UnifiedGraphExplorer({
 
   function applyFilters() {
     if (layer === "coauthorship") {
-      setCoauthorshipFilters(normalizeCoauthorshipFilters(coauthorshipDraft));
+      startGraphTransition(() => {
+        setCoauthorshipFilters(normalizeCoauthorshipFilters(coauthorshipDraft));
+      });
       return;
     }
-    setSemanticFilters(normalizeSemanticFilters(semanticDraft));
+    startGraphTransition(() => {
+      setSemanticFilters(normalizeSemanticFilters(semanticDraft));
+    });
   }
 
   function resetFilters() {
@@ -389,9 +473,13 @@ export function UnifiedGraphExplorer({
         communityId: "",
         maxNodes: defaultNodeLimitValue(),
         minEdgeWeight: "",
+        minDegree: "",
+        largestComponentOnly: false,
       };
       setCoauthorshipDraft(nextDraft);
-      setCoauthorshipFilters(normalizeCoauthorshipFilters(nextDraft));
+      startGraphTransition(() => {
+        setCoauthorshipFilters(normalizeCoauthorshipFilters(nextDraft));
+      });
     } else {
       const nextDraft = {
         publicationId: "",
@@ -400,9 +488,13 @@ export function UnifiedGraphExplorer({
         communityId: "",
         maxNodes: defaultNodeLimitValue(),
         minEdgeWeight: "",
+        minDegree: "",
+        largestComponentOnly: false,
       };
       setSemanticDraft(nextDraft);
-      setSemanticFilters(normalizeSemanticFilters(nextDraft));
+      startGraphTransition(() => {
+        setSemanticFilters(normalizeSemanticFilters(nextDraft));
+      });
     }
     setSelectedNodeId(null);
     setSelectedEdgeId(null);
@@ -439,7 +531,9 @@ export function UnifiedGraphExplorer({
         researcherId: selectedNodeId,
       };
       setCoauthorshipDraft(nextDraft);
-      setCoauthorshipFilters(normalizeCoauthorshipFilters(nextDraft));
+      startGraphTransition(() => {
+        setCoauthorshipFilters(normalizeCoauthorshipFilters(nextDraft));
+      });
       return;
     }
 
@@ -448,13 +542,41 @@ export function UnifiedGraphExplorer({
       publicationId: selectedNodeId,
     };
     setSemanticDraft(nextDraft);
-    setSemanticFilters(normalizeSemanticFilters(nextDraft));
+    startGraphTransition(() => {
+      setSemanticFilters(normalizeSemanticFilters(nextDraft));
+    });
   }
+
+  const isGraphRefreshing =
+    isApplyingFilters || activeGraph.isFetching || activeStatus.isFetching;
+  const isGraphCanvasBusy = isGraphRefreshing || isCanvasRendering;
+  const graphCanvasHint = isGraphRefreshing
+    ? "Refreshing filtered subgraph..."
+    : isCanvasRendering
+      ? isLargeGraph
+        ? `Rendering graph in the browser (${activeNodeCount} nodes, ${activeEdgeCount} edges)...`
+        : "Rendering graph in the browser..."
+      : "Drag, zoom, select.";
 
   const activeHasFilters =
     layer === "coauthorship"
-      ? hasAnyValue(coauthorshipDraft)
-      : hasAnyValue(semanticDraft);
+      ? hasAnyValue({
+          researcherId: coauthorshipDraft.researcherId,
+          organizationId: coauthorshipDraft.organizationId,
+          communityId: coauthorshipDraft.communityId,
+          maxNodes: coauthorshipDraft.maxNodes,
+          minEdgeWeight: coauthorshipDraft.minEdgeWeight,
+          minDegree: coauthorshipDraft.minDegree,
+        }) || hasAnyToggle({ largestComponentOnly: coauthorshipDraft.largestComponentOnly })
+      : hasAnyValue({
+          publicationId: semanticDraft.publicationId,
+          organizationId: semanticDraft.organizationId,
+          publicationYear: semanticDraft.publicationYear,
+          communityId: semanticDraft.communityId,
+          maxNodes: semanticDraft.maxNodes,
+          minEdgeWeight: semanticDraft.minEdgeWeight,
+          minDegree: semanticDraft.minDegree,
+        }) || hasAnyToggle({ largestComponentOnly: semanticDraft.largestComponentOnly });
 
   const selectedNodePayload =
     layer === "coauthorship" && selectedNode && "full_name" in selectedNode
@@ -523,6 +645,11 @@ export function UnifiedGraphExplorer({
           onCenterSelection={centerSelection}
           canCenterSelection={Boolean(selectedNodeId)}
         />
+        {isGraphRefreshing ? (
+          <div className="mt-4 rounded-[1rem] border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-zinc-700">
+            Updating the graph view. The backend is preparing a new filtered subgraph and the canvas is being re-rendered.
+          </div>
+        ) : null}
         {layer === "coauthorship" && coauthorshipOrganizationLegend.length > 0 ? (
           <div className="mt-5 space-y-3 border-t border-zinc-100 pt-4">
             <div className="flex items-center justify-between gap-4">
@@ -594,10 +721,23 @@ export function UnifiedGraphExplorer({
               title={layer === "coauthorship" ? "Coauthorship layer" : "Semantic layer"}
               description={`Build ${activeStatus.data?.build_id ?? "n/a"} · ${activeGraph.data.nodes.length} nodes · ${activeGraph.data.edges.length} edges`}
             >
-              <GraphCanvas
-                ref={canvasRef}
-                hint="Drag, zoom, select."
-              />
+              <div className="relative">
+                <GraphCanvas
+                  ref={canvasRef}
+                  hint={graphCanvasHint}
+                />
+                {isGraphCanvasBusy ? (
+                  <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-[1.5rem] bg-white/65 backdrop-blur-[1px]">
+                    <div className="rounded-full border border-[color:var(--border)] bg-white px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-zinc-600">
+                      {isGraphRefreshing
+                        ? "Updating graph data"
+                        : isLargeGraph
+                          ? "Rendering large graph"
+                          : "Rendering graph"}
+                    </div>
+                  </div>
+                ) : null}
+              </div>
             </Panel>
 
             <div className="grid gap-4 xl:grid-cols-3">

--- a/frontend/src/hooks/use-graphs.ts
+++ b/frontend/src/hooks/use-graphs.ts
@@ -27,6 +27,8 @@ function hasCoauthorshipFilters(filters: CoauthorshipSubgraphFilters): boolean {
       filters.organization_id ||
       filters.max_nodes ||
       filters.min_edge_weight ||
+      filters.min_degree ||
+      filters.largest_component_only ||
       filters.community_id !== undefined,
   );
 }
@@ -38,6 +40,8 @@ function hasSemanticFilters(filters: SemanticSubgraphFilters): boolean {
       filters.publication_year ||
       filters.max_nodes ||
       filters.min_edge_weight ||
+      filters.min_degree ||
+      filters.largest_component_only ||
       filters.community_id !== undefined,
   );
 }

--- a/frontend/src/lib/api/admin.ts
+++ b/frontend/src/lib/api/admin.ts
@@ -42,6 +42,10 @@ export type EUNICESeedStatus = {
   api_base_url: string;
   community_id: string;
   product_type: string;
+  publication_date_from: string;
+  publication_date_to: string;
+  pagination_mode: string;
+  page_size: number;
   default_max_publications: number;
   table_counts: Record<string, number>;
   latest_ingestion_run_id: string | null;
@@ -50,13 +54,15 @@ export type EUNICESeedStatus = {
 
 export type EUNICESeedLoadRequest = {
   max_publications?: number | null;
-  publication_year_from?: number | null;
-  publication_year_to?: number | null;
 };
 
 export type EUNICESeedLoadResponse = {
   api_base_url: string;
   community_id: string;
+  publication_date_from: string;
+  publication_date_to: string;
+  pagination_mode: string;
+  page_size: number;
   ingestion_run_id: string | null;
   max_publications: number | null;
   publication_records_processed: number;

--- a/frontend/src/lib/graphs/types.ts
+++ b/frontend/src/lib/graphs/types.ts
@@ -143,6 +143,8 @@ export type CoauthorshipSubgraphFilters = {
   organization_id?: string;
   max_nodes?: number;
   min_edge_weight?: number;
+  min_degree?: number;
+  largest_component_only?: boolean;
   community_id?: number;
 };
 
@@ -152,6 +154,8 @@ export type SemanticSubgraphFilters = {
   publication_year?: number;
   max_nodes?: number;
   min_edge_weight?: number;
+  min_degree?: number;
+  largest_component_only?: boolean;
   community_id?: number;
 };
 


### PR DESCRIPTION
- Added constraints for publication dates in the backend and frontend documentation.
- Updated the EUNICE seed operations to reflect the fixed date window for publications.
- Enhanced the Graph API response to include pagination details and effective API page size.
- Introduced new filters for graph exploration, including min degree and largest component only.
- Improved the rendering performance of the graph explorer for larger datasets.
- Refactored the API proxy request handling to manage timeouts and response headers more effectively.
- Removed unnecessary publication year inputs from the EUNICE seed form in the admin console.